### PR TITLE
jira: Add a custom field mapping resolver

### DIFF
--- a/jirate/tests/__init__.py
+++ b/jirate/tests/__init__.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python
+
+from jira.resources import Issue, dict2resource
+
+fake_user = {'self': 'https://domain.com/rest/api/2/user?username=porkchop', 'key': 'porkchop', 'name': 'porkchop', 'emailAddress': 'porkchop@domain.com', 'avatarUrls': {'48x48': 'https://domain.com/secure/useravatar?avatarId=1', '24x24': 'https://domain.com/secure/useravatar?size=small&avatarId=1', '16x16': 'https://domain.com/secure/useravatar?size=xsmall&avatarId=1', '32x32': 'https://domain.com/secure/useravatar?size=medium&avatarId=1'}, 'displayName': 'Chop Pork', 'active': True, 'deleted': False, 'timeZone': 'America/New_York', 'locale': 'en_US', 'groups': {'size': 9, 'items': []}, 'applicationRoles': {'size': 1, 'items': []}, 'expand': 'groups,applicationRoles'}
+
+
+fake_fields = [
+    {'clauseNames': ['cf[1234567]', 'Fixed in Build'],
+        'custom': True,
+        'id': 'customfield_1234567',
+        'name': 'Fixed in Build',
+        'navigable': True,
+        'orderable': True,
+        'schema': {'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:textfield',
+                   'customId': 1234567,
+                   'type': 'string'},
+        'searchable': True},
+    {'clauseNames': ['cf[1234568]', 'Score'],
+        'custom': True,
+        'id': 'customfield_1234568',
+        'name': 'Score',
+        'navigable': True,
+        'orderable': True,
+        'schema': {'custom': 'org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlynumber',
+                   'customId': 1234568,
+                   'type': 'number'},
+        'searchable': True},
+    {'clauseNames': ['cf[1234569]', 'Array Tests'],
+        'custom': True,
+        'id': 'customfield_1234569',
+        'name': 'Array Tests',
+        'navigable': True,
+        'orderable': True,
+        'schema': {'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:multiselect',
+                   'customId': 1234569,
+                   'items': 'option',
+                   'type': 'array'},
+        'searchable': True}]
+
+
+fake_issues = {
+    'TEST-1': {'expand': 'renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations',
+               'fields': {'aggregateprogress': {'progress': 0, 'total': 0},
+                          'aggregatetimeestimate': None,
+                          'aggregatetimeoriginalestimate': None,
+                          'aggregatetimespent': None,
+                          'archivedby': None,
+                          'archiveddate': None,
+                          'assignee': None,
+                          'attachment': [],
+                          'comment': [],
+                          'components': [],
+                          'created': '2023-08-03T10:28:48.366+0000',
+                          'customfield_1234567': None,
+                          'customfield_1234568': None,
+                          'customfield_1234569': None,
+                          'description': 'Test Description 1',
+                          'duedate': '2024-01-30',
+                          'environment': None,
+                          'fixVersions': [],
+                          'issuelinks': [],
+                          'issuetype': {'avatarId': 13263,
+                                        'description': 'A bug',
+                                        'id': '1',
+                                        'name': 'Bug',
+                                        'self': 'https://domain.com/rest/api/2/issuetype/1',
+                                        'subtask': False},
+                          'labels': ['label1', 'label2'],
+                          'lastViewed': '2023-11-22T15:51:50.281+0000',
+                          'priority': {
+                   'id': '10200',
+                   'name': 'Normal',
+                   'self': 'https://domain.com/rest/api/2/priority/10200'},
+                   'progress': {'progress': 0, 'total': 0},
+                   'project': {'id': '1234',
+                               'key': 'TEST',
+                               'name': 'Test Project',
+                               'projectCategory': {'description': 'Test Projects',
+                                                   'id': '1073',
+                                                   'name': 'Projecto',
+                                                   'self': 'https://domain.com/rest/api/2/projectCategory/1073'},
+                               'projectTypeKey': 'software',
+                               'self': 'https://domain.com/rest/api/2/project/1234'},
+                   'reporter': {'active': True,
+                                'displayName': 'Pork Chop',
+                                'emailAddress': 'pchop@domai.com',
+                                'key': 'JIRAUSER1',
+                                'name': 'pchop@domain.com',
+                                'self': 'https://domain.com/rest/api/2/user?username=pchop%40domain.com',
+                                'timeZone': 'Asia/Kolkata'},
+                   'resolution': None,
+                   'resolutiondate': None,
+                   'security': None,
+                   'status': {'description': 'Initial creation status. ',
+                              'id': '10',
+                              'name': 'New',
+                              'self': 'https://domain.com/rest/api/2/status/10016',
+                              'statusCategory': {'colorName': 'default',
+                                                 'id': 2,
+                                                 'key': 'new',
+                                                 'name': 'To Do',
+                                                 'self': 'https://domain.com/rest/api/2/statuscategory/2'}},
+                   'subtasks': [],
+                   'summary': 'Test 1',
+                   'timeestimate': None,
+                   'timeoriginalestimate': None,
+                   'timespent': None,
+                   'timetracking': {},
+                   'updated': '2023-11-30T15:06:39.875+0000',
+                   'versions': [{'archived': False,
+                                 'description': '',
+                                 'id': '6',
+                                 'name': 'version-6',
+                                 'released': False,
+                                 'self': 'https://domain.com/rest/api/2/version/6'}],
+                   'votes': {'hasVoted': False,
+                             'self': 'https://domain.com/rest/api/2/issue/TEST-1/votes',
+                             'votes': 0},
+                   'watches': {'isWatching': False,
+                               'self': 'https://domain.com/rest/api/2/issue/TEST-1/watchers',
+                               'watchCount': 2},
+                   'worklog': {'maxResults': 20,
+                               'startAt': 0,
+                               'total': 0,
+                               'worklogs': []},
+                   'workratio': -1},
+               'id': '1000001',
+               'key': 'TEST-1',
+               'self': 'https://domain.com/rest/api/2/issue/1000001'},
+
+    'TEST-2': {'expand': 'renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations',
+               'fields': {'aggregateprogress': {'progress': 0, 'total': 0},
+                          'aggregatetimeestimate': None,
+                          'aggregatetimeoriginalestimate': None,
+                          'aggregatetimespent': None,
+                          'archivedby': None,
+                          'archiveddate': None,
+                          'assignee': None,
+                          'attachment': [],
+                          'comment': [],
+                          'components': ['porkchop'],
+                          'created': '2023-08-03T10:28:48.366+0000',
+                          'customfield_1234567': 'build-2',
+                          'customfield_1234568': None,
+                          'customfield_1234569': None,
+                          'description': 'Test Description 2',
+                          'duedate': '2024-01-30',
+                          'environment': None,
+                          'fixVersions': [],
+                          'issuelinks': [],
+                          'issuetype': {'avatarId': 13263,
+                                        'description': 'A bug',
+                                        'id': '1',
+                                        'name': 'Bug',
+                                        'self': 'https://domain.com/rest/api/2/issuetype/1',
+                                        'subtask': False},
+                          'labels': ['label2'],
+                          'lastViewed': '2023-11-22T15:51:50.281+0000',
+                          'priority': {
+                   'id': '10200',
+                   'name': 'Normal',
+                   'self': 'https://domain.com/rest/api/2/priority/10200'},
+                   'progress': {'progress': 0, 'total': 0},
+                   'project': {'id': '1234',
+                               'key': 'TEST',
+                               'name': 'Test Project',
+                               'projectCategory': {'description': 'Test Projects',
+                                                   'id': '1073',
+                                                   'name': 'Projecto',
+                                                   'self': 'https://domain.com/rest/api/2/projectCategory/1073'},
+                               'projectTypeKey': 'software',
+                               'self': 'https://domain.com/rest/api/2/project/1234'},
+                   'reporter': {'active': True,
+                                'displayName': 'Pork Chop',
+                                'emailAddress': 'pchop@domai.com',
+                                'key': 'JIRAUSER1',
+                                'name': 'pchop@domain.com',
+                                'self': 'https://domain.com/rest/api/2/user?username=pchop%40domain.com',
+                                'timeZone': 'Asia/Kolkata'},
+                   'resolution': None,
+                   'resolutiondate': None,
+                   'security': None,
+                   'status': {'description': 'Initial creation status. ',
+                              'id': '10',
+                              'name': 'New',
+                              'self': 'https://domain.com/rest/api/2/status/10016',
+                              'statusCategory': {'colorName': 'default',
+                                                 'id': 2,
+                                                 'key': 'new',
+                                                 'name': 'To Do',
+                                                 'self': 'https://domain.com/rest/api/2/statuscategory/2'}},
+                   'subtasks': [],
+                   'summary': 'Test 1',
+                   'timeestimate': None,
+                   'timeoriginalestimate': None,
+                   'timespent': None,
+                   'timetracking': {},
+                   'updated': '2023-11-30T15:06:39.875+0000',
+                   'versions': [{'archived': False,
+                                 'description': '',
+                                 'id': '6',
+                                 'name': 'version-6',
+                                 'released': False,
+                                 'self': 'https://domain.com/rest/api/2/version/6'}],
+                   'votes': {'hasVoted': False,
+                             'self': 'https://domain.com/rest/api/2/issue/TEST-1/votes',
+                             'votes': 0},
+                   'watches': {'isWatching': False,
+                               'self': 'https://domain.com/rest/api/2/issue/TEST-1/watchers',
+                               'watchCount': 2},
+                   'worklog': {'maxResults': 20,
+                               'startAt': 0,
+                               'total': 0,
+                               'worklogs': []},
+                   'workratio': -1},
+               'id': '1000002',
+               'key': 'TEST-2',
+               'self': 'https://domain.com/rest/api/2/issue/1000002'}
+}
+
+
+class fake_jira_session():
+    def get(url):
+        pass
+
+    def post(url, data=None):
+        pass
+
+    def delete(url):
+        pass
+
+
+class fake_jira():
+    def _get_url(self, url_fragment):
+        pass
+
+    def _get_json(self, url_fragment):
+        pass
+
+    def add_simple_link(self, issue, link):
+        pass
+
+    def search_users(self, username):
+        pass
+
+    def fields(self):
+        return fake_fields
+
+    def search_issues(self, seach_query, startAt=None, maxResults=None):
+        pass
+
+    def create_issue(self, **args):
+        pass
+
+    def issue(self, issue_key):
+        if issue_key.upper() not in fake_issues:
+            return None
+        ret = Issue(None, None)
+        ret.raw = fake_issues[issue_key]
+        dict2resource(fake_issues[issue_key], ret)
+        return ret
+
+    def issue_link_types(self):
+        pass
+
+    def create_issue_link(self, text, left_key, right_key):
+        pass
+
+    def remote_links(self, issue_key):
+        pass
+
+    def remote_link(self, left_key, right_key):
+        pass
+
+    def delete_issue_link(self, left_key, right_key):
+        pass
+
+    def project(self, project_key):
+        pass
+
+    def myself(self):
+        return fake_user
+
+    _session = fake_jira_session()

--- a/jirate/tests/test_jirate.py
+++ b/jirate/tests/test_jirate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+from jirate.jboard import Jirate
+from jirate.tests import fake_jira, fake_user
+
+import pytest  # NOQA
+
+
+fake_jirate = Jirate(fake_jira())
+
+
+def test_jirate_myself():
+    assert not fake_jirate._user
+    me = fake_jirate.user
+    assert fake_jirate.user
+    assert me == fake_user
+
+
+def test_jirate_issue():
+    issue = fake_jirate.issue('TEST-9999')
+    assert issue is None
+    issue = fake_jirate.issue('TEST-1')
+    assert issue
+
+
+def test_jirate_basicfields():
+    # Normal fields should be accessible via the field() function
+    issue = fake_jirate.issue('TEST-2')
+
+    val = issue.fields.description
+
+    assert fake_jirate.field(issue, 'description') == val
+    assert issue.field('description') == val
+
+
+def test_jirate_customfields():
+    issue = fake_jirate.issue('TEST-2')
+
+    # change if you alter issue or above predefined fake issue
+    # data
+    expected = 'build-2'
+
+    assert issue.fields.customfield_1234567 == expected
+    assert issue.raw['fields']['customfield_1234567'] == expected
+
+    # too bad...
+    with pytest.raises(AttributeError):
+        issue.fields.fixed_in_build
+
+    # Test one-way
+    assert fake_jirate.field('TEST-2', 'fixed_in_build') == expected
+    assert fake_jirate.field('TEST-2', 'Fixed in Build') == expected
+    assert fake_jirate.field('TEST-2', 'customfield_1234567') == expected
+
+    # Negative test
+    with pytest.raises(AttributeError):
+        fake_jirate.field('TEST-2', 'arglebargle')
+
+    assert fake_jirate.field(issue, 'fixed_in_build') == expected
+    assert fake_jirate.field(issue, 'Fixed in Build') == expected
+    assert fake_jirate.field(issue, 'customfield_1234567') == expected
+
+    # Negative test
+    with pytest.raises(AttributeError):
+        fake_jirate.field(issue, 'arglebargle')
+
+    # Test issue
+    assert issue.field('fixed_in_build') == expected
+    assert issue.field('Fixed in Build') == expected
+    assert issue.field('customfield_1234567') == expected
+
+    # Negative test
+    with pytest.raises(AttributeError):
+        issue.field('arglebargle')


### PR DESCRIPTION
The way the jira module for python is implemented, there's no simple way to feed the server's custom
field definitions to produce something human-readable that can be used in code, i.e.:

  issue.fields.fixed_in_build
    vs.
  issue.fields.custom_321789045789

or:

  issue.raw['fields']['fixed_in_build']
    vs.
  issue.raw['fields']['custom_321789045789']

The raw JSON returned from the JIRA server for an issue does not contain any of the mapping information, which must be retrieved separately. Fortunately, this changes infrequently, so we can cache it in the Jirate() object for now, although if we want this to work for long-running processes, it should be updated periodically.

So, we're left with:

   jirate.field(issue, 'fixed_in_build')
     or
   issue.field('fixed_in_build')

... which lazy-loads the field definitions and uses a combination of toolchest's nym() function and the raw field names to try to find the field the caller was looking for.

Additional notes:

* Never do a round-trip to the JIRA server when called from the Issue object.

* Do not overwrite jira.resources.Issue.field if it exists.

* Raise AttributeError if a field does not exist.