### PR TITLE
jira: Fix up parent linking

### DIFF
--- a/jirate/jira_input.py
+++ b/jirate/jira_input.py
@@ -12,6 +12,10 @@ def in_number(value):
     return float(value)
 
 
+def in_key(value):
+    return {'key': value}
+
+
 def in_name(value):
     return {'name': value}
 
@@ -40,6 +44,7 @@ _input_renderers = {
     'version': in_name,
     'securitylevel': in_name,
     'option-with-child': in_owc,
+    'issuelink': in_key,
     'user': in_string   # When setting array, you specify 'name': name
                         # When setting assignee, you just give the name
                         # as a string

--- a/jirate/tests/__init__.py
+++ b/jirate/tests/__init__.py
@@ -363,7 +363,7 @@ fake_issues = {
                           'customfield_1234574': ['one', 2.0],
                           'customfield_1234575': '2022-08-01',
                           'customfield_1234576': '2019-12-25T02:10:00.000+0000',
-                          'customfield_1234577': 'TEST-2',
+                          'customfield_1234577': {'key': 'TEST-2'},
                           'customfield_1234578': {'name': 'Option1', 'value': 'option_one'},
                           'customfield_1234579': {'name': 'Option1', 'value': 'option_one', 'child': {'name': 'child1', 'value': 'child_value'}},
                           'customfield_1234580': {

--- a/jirate/tests/test_input.py
+++ b/jirate/tests/test_input.py
@@ -100,6 +100,11 @@ def test_trans_array_any():
 # but are strings
 
 
+def test_trans_issuelink():
+    inp = {'related_issue': 'TEST-2'}
+    out = {'customfield_1234577': {'name': 'TEST-2'}}
+
+
 def test_trans_option():
     inp = {'option_value': 'one'}
     out = {'customfield_1234578': {'value': 'One'}}

--- a/jirate/tests/test_render.py
+++ b/jirate/tests/test_render.py
@@ -101,8 +101,8 @@ field_test_info = [
     # Datetime value
     pytest.param('customfield_1234576', 'Datetime Value', '2019-12-24 21:10:00 EST'),
 
-    # Related Issue (issue key) - TODO
-    # assert render_field_data('customfield_1234577','TEST-2', ???),
+    # Related Issue (issue key)
+    pytest.param('customfield_1234577', 'Related Issue', 'TEST-2'),
 
     # Option (value),
     pytest.param('customfield_1234578', 'Option Value', 'option_one'),


### PR DESCRIPTION
Previous round of commits:
- didn't factor in that metadata was now always required when calling create(), and
-  left code in when doing subtask creation that was needed before we expanded transmogrify_input().

This fixes those related issues and adds tests for issuelink values, which was missing.