### PR TITLE
Use create() instead of new() when processing templates

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: jirate
-Version: 0.6.5
+Version: 0.7.0
 Summary: Python CLI for JIRA and Trello
 Author: Lon Hohberger
 Author-email: lon@metamorphism.com

--- a/contrib/example-template.yaml
+++ b/contrib/example-template.yaml
@@ -19,7 +19,7 @@ issues:
         description: "Description for subtask 2"
       - summary: "Eat a snack as a reward for all my hard work"
         description: "Description for subtask 3"
-  - issue_type: "Story"
+  - issuetype: "Story"
     summary: "Make sure I stop using the default template"
     description: "People won't appreciate it if I keep filing the same issues over and over again."
     subtasks:

--- a/jirate/__init__.py
+++ b/jirate/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/python3
 
-__version__ = '0.6.5'
+__version__ = '0.7.0'

--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -365,8 +365,7 @@ class Jirate(object):
 
         # Transmogrify other fields
         new_args = transmogrify_input(field_definitions, **args)
-        ret = self.jira.create_issue(**new_args)
-        return ret
+        return self.jira.create_issue(**new_args)
 
     def update_issue(self, issue_alias, field_definitions=None, **kwargs):
         """Update an issue using key/value pairs
@@ -685,8 +684,8 @@ class JiraProject(Jirate):
         return ret
 
     def _index_issue(self, issue):
-        if issue.raw['key'] not in self._config['issue_map']:
-            self._config['issue_map'][issue.raw['key']] = issue
+        if issue.key not in self._config['issue_map']:
+            self._config['issue_map'][issue.key] = issue
 
     def _index_issues(self, issues):
         if 'issue_map' not in self._config:

--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -830,7 +830,9 @@ class JiraProject(Jirate):
         return self._issue_types
 
     # Returns a dict that JIRA should just give us.
-    def issue_metadata(self, issue_type_or_id):
+    def issue_metadata(self, issue_type_or_id, project_key=None):
+        if not project_key:
+            project_key = self.project_name
         itype = None
         for issuetype in self.issue_types:
             if issuetype.id == issue_type_or_id or nym(issuetype.name) == nym(issue_type_or_id):
@@ -842,7 +844,7 @@ class JiraProject(Jirate):
         start = 0
         chunk_len = 50
         while True:
-            new_fields = self.jira.project_issue_fields(self.project_name, itype.id, startAt=start, maxResults=chunk_len)
+            new_fields = self.jira.project_issue_fields(project_key, itype.id, startAt=start, maxResults=chunk_len)
             for field in new_fields:
                 fields.append(field.raw)
             if new_fields.isLast:

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -401,6 +401,23 @@ def print_creation_fields(metadata):
     render_matrix(matrix)
 
 
+def _metadata_by_type(project, issuetype):
+    try:
+        metadata = project.issue_metadata(issuetype)
+    except JIRAError as e:
+        if 'text: Issue Does Not Exist' in str(e):
+            print('The createmeta API does not exist on this JIRA instance.')
+        else:
+            print(e)
+        return (1, False)
+
+    if not metadata:
+        print(f'Valid issue types for {project.project_name}:')
+        list_issue_types(project.issue_types)
+        raise ValueError(f'Invalid issue type: {issuetype}')
+    return metadata
+
+
 # new_issue is way too easy. Let's make it *incredibly* complicated!
 def create_issue(args):
     desc = None
@@ -411,20 +428,7 @@ def create_issue(args):
         print('Incorrect number of arguments (not divisible by 2)')
         return (1, False)
 
-    try:
-        metadata = args.project.issue_metadata(issuetype)
-    except JIRAError as e:
-        if 'text: Issue Does Not Exist' in str(e):
-            print('The createmeta API does not exist on this JIRA instance.')
-        else:
-            print(e)
-        return (1, False)
-
-    if not metadata:
-        print('Invalid issue type:', issuetype)
-        print(f'Valid issue types for {args.project.project_name}:')
-        list_issue_types(args)
-        return (1, False)
+    metadata = _metadata_by_type(args.project, issuetype)
 
     values = {}
     argv = copy.copy(args.args)
@@ -462,7 +466,32 @@ def create_issue(args):
     return (0, True)
 
 
+def _parse_creation_args(issue_data, required_fields=None, reserved_fields=None, translate_fields=None, start_vals=None):
+    ret = {}
+    if start_vals:
+        ret = start_vals
+
+    for key in issue_data:
+        actual_key = key
+        if translate_fields and key in translate_fields:
+            actual_key = translate_fields[key]
+        if not reserved_fields or actual_key not in reserved_fields:
+            ret[actual_key] = issue_data[key]
+    missing = []
+    if required_fields:
+        for key in required_fields:
+            if key not in ret:
+                missing.append(key)
+        if missing:
+            raise ValueError(f'Missing required fields: {missing}')
+    return ret
+
+
 def create_from_template(args):
+    # Cache for issue createmeta information
+    metadata_by_type = {}
+    _subtask = 'Sub-task'  # To prevent case / typos / etc
+
     # TODO: consider using Jira's bulk issue creation
     # TODO: support reading arbitrary fields from the template
     all_filed = []  # We keep issue keys here because we'll need to refresh anyway
@@ -476,19 +505,40 @@ def create_from_template(args):
         raise e
 
     for issue in template['issues']:
-        filed = {}
-        if 'description' not in issue:
-            issue['description'] = ""
-        parent = args.project.new(issue['summary'], description=issue['description'], issue_type=issue['issue_type'])
-        filed['parent'] = parent.raw['key']
+        reserved_fields = ['subtasks']
+        required_fields = ['summary']
+        translate_fields = {'issue_type': 'issuetype'}
 
-        if issue['subtasks']:
+        # These may be overridden
+        start_fields = {'issuetype': 'Task', 'project': args.project.project_name}
+
+        creation_fields = _parse_creation_args(issue, required_fields, reserved_fields, translate_fields, start_fields)
+
+        # Cache all metadata now (so we can debug subtask creation if needed.
+        issuetype = creation_fields['issuetype']
+        if issuetype not in metadata_by_type:
+            metadata_by_type[issuetype] = _metadata_by_type(args.project, issuetype)
+        if 'subtasks' in issue and issue['subtasks']:
+            metadata_by_type[_subtask] = _metadata_by_type(args.project, _subtask)
+        metadata = metadata_by_type[issuetype]
+
+        filed = {}
+        # args.project.jira = fake_jira()  # debugging
+        parent = args.project.create(metadata['fields'], **creation_fields)
+        filed['parent'] = parent.key
+
+        if 'subtasks' in issue and issue['subtasks']:
+            # Set once
+            metadata = metadata_by_type[_subtask]
             filed['subtasks'] = []
             for subtask in issue['subtasks']:
-                if 'description' not in subtask:
-                    subtask['description'] = ""
-                child = args.project.subtask(parent.raw['key'], subtask['summary'], subtask['description'])
-                filed['subtasks'].append(child.raw['key'])
+                reserved_fields = ['subtasks', 'issuetype', 'parent']
+                # required_fields and translate_fields is same
+                start_fields = {'issuetype': _subtask, 'parent': parent.key}
+                creation_fields = _parse_creation_args(subtask, required_fields, reserved_fields, translate_fields, start_fields)
+
+                child = args.project.create(metadata['fields'], **creation_fields)
+                filed['subtasks'].append(child.key)
         all_filed.append(filed)
 
     # Need to refresh to that issues get re-fetched to include subtasks

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -507,12 +507,8 @@ def create_from_template(args):
     for issue in template['issues']:
         reserved_fields = ['subtasks']
         required_fields = ['summary']
-        translate_fields = {'issue_type': 'issuetype'}
 
-        # These may be overridden
-        start_fields = {'issuetype': 'Task', 'project': args.project.project_name}
-
-        creation_fields = _parse_creation_args(issue, required_fields, reserved_fields, translate_fields, start_fields)
+        creation_fields = _parse_creation_args(issue, required_fields, reserved_fields)
 
         # Cache all metadata now (so we can debug subtask creation if needed.
         issuetype = creation_fields['issuetype']
@@ -523,7 +519,6 @@ def create_from_template(args):
         metadata = metadata_by_type[issuetype]
 
         filed = {}
-        # args.project.jira = fake_jira()  # debugging
         parent = args.project.create(metadata['fields'], **creation_fields)
         filed['parent'] = parent.key
 

--- a/jirate/jira_input.py
+++ b/jirate/jira_input.py
@@ -151,7 +151,7 @@ def transmogrify_input(field_definitions, **args):
         metadata in field_definitions
     """
     drop_fields = ['attachment', 'reporter', 'issuelinks']  # These are not set during create/update
-    simple_fields = ['project', 'issuetype']                # Don't process these fields at all
+    simple_fields = ['project', 'issuetype', 'summary', 'description']                # Don't process these fields at all
     output = {}
     def_map = {}
 
@@ -163,13 +163,13 @@ def transmogrify_input(field_definitions, **args):
 
     for field in args:
         value = args[field]
+        if field in simple_fields:
+            output[field] = value
+            continue
         if field not in def_map:
             continue
         field_id = def_map[field]
         if field_id in drop_fields:
-            continue
-        if field_id in simple_fields:
-            output[field_id] = value
             continue
         output[field_id] = transmogrify_value(value, field_definitions[field_id])
     return output

--- a/jirate/jira_input.py
+++ b/jirate/jira_input.py
@@ -151,7 +151,7 @@ def transmogrify_input(field_definitions, **args):
         metadata in field_definitions
     """
     drop_fields = ['attachment', 'reporter', 'issuelinks']  # These are not set during create/update
-    simple_fields = ['project', 'issuetype', 'summary', 'description']                # Don't process these fields at all
+    simple_fields = ['project', 'issuetype', 'summary', 'description', 'parent']                # Don't process these fields at all
     output = {}
     def_map = {}
 

--- a/jirate/schemas/issue.yaml
+++ b/jirate/schemas/issue.yaml
@@ -5,7 +5,7 @@ type: object
 description: JIRA issue.
 required:
   - summary
-  - issue_type
+  - issuetype
 
 properties:
   summary:
@@ -14,7 +14,7 @@ properties:
   description:
     description: Description for the JIRA issue. Can be multiple lines and use JIRA markup.
     type: string
-  issue_type:
+  issuetype:
     description: JIRA issue type like Story, Epic, etc. Possible values vary between projects.
     type: string
   subtasks:

--- a/jirate/schemas/subtask.yaml
+++ b/jirate/schemas/subtask.yaml
@@ -2,7 +2,7 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 $id: "jirate:subtask.yaml"
 type: object
-description: JIRA sub-task. Similar to an issue, but can't set the issue_type or add sub-tasks to it.
+description: JIRA sub-task. Similar to an issue, but can't set the issuetype or add sub-tasks to it.
 required:
   - summary
 

--- a/jirate/tests/__init__.py
+++ b/jirate/tests/__init__.py
@@ -2,6 +2,10 @@
 
 from jira.client import JIRA
 from jira.resources import Issue, dict2resource
+from jirate.args import GenericArgs
+from jirate.decor import pretty_print
+
+testx = 1
 
 fake_user = {'self': 'https://domain.com/rest/api/2/user?username=porkchop', 'key': 'porkchop', 'name': 'porkchop', 'emailAddress': 'porkchop@domain.com', 'avatarUrls': {'48x48': 'https://domain.com/secure/useravatar?avatarId=1', '24x24': 'https://domain.com/secure/useravatar?size=small&avatarId=1', '16x16': 'https://domain.com/secure/useravatar?size=xsmall&avatarId=1',
                                                                                                                                                                           '32x32': 'https://domain.com/secure/useravatar?size=medium&avatarId=1'}, 'displayName': 'Chop Pork', 'active': True, 'deleted': False, 'timeZone': 'America/New_York', 'locale': 'en_US', 'groups': {'size': 9, 'items': []}, 'applicationRoles': {'size': 1, 'items': []}, 'expand': 'groups,applicationRoles'}
@@ -530,7 +534,16 @@ class fake_jira(JIRA):
         pass
 
     def create_issue(self, **args):
-        pass
+        global testx
+
+        ret = GenericArgs()
+        proj = args['project']
+        ret.key = f'{proj}-{testx}'
+        testx = testx + 1
+        ret.raw = {'fields': args}
+        ret.raw['fields']['project'] = {'key': proj}
+        pretty_print(ret)
+        return ret
 
     def issue(self, issue_key):
         if issue_key.upper() not in fake_issues:

--- a/jirate/tests/__init__.py
+++ b/jirate/tests/__init__.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 
+import jira.utils
+# Hack to paste input to output
+jira.utils.json_loads = lambda val: val
+
 from jira.client import JIRA
-from jira.resources import Issue, dict2resource
+from jira.resources import Issue, dict2resource, Project
 from jirate.args import GenericArgs
 from jirate.decor import pretty_print
 
@@ -301,7 +305,7 @@ fake_issues = {
                                        'self': 'https://domain.com/rest/api/2/user?username=rory',
                                        'timeZone': 'America/New_York'},
                           'attachment': [],
-                          'comment': [],
+                          'comment': {'comments': []},
                           'components': [{'name': 'food, pork'}, {'name': 'food, carrot'}],
                           'created': '2023-08-03T10:28:48.366+0000',
                           'description': 'Test Description 1',
@@ -409,7 +413,7 @@ fake_issues = {
                           'archiveddate': None,
                           'assignee': None,
                           'attachment': [],
-                          'comment': [],
+                          'comment': {'comments': []},
                           'components': [],
                           'created': '2023-08-03T10:28:48.366+0000',
                           'customfield_1234567': None,
@@ -488,6 +492,116 @@ fake_issues = {
 }
 
 
+fake_statuses = [
+        {'id': '12363',
+         'name': 'Bug',
+         'subtask': False,
+         'statuses': [{'id': '10000', 'name': 'New', 'statusCategory': { 'id': 2, 'name': 'To Do'}},
+                      {'id': '10001', 'name': 'In Progress', 'statusCategory': { 'id': 4, 'name': 'In Progress' }},
+                      {'id': '10002', 'name': 'Done', 'statusCategory': { 'id': 6, 'name': 'Done'}}
+                     ]
+         }
+        ]
+
+fake_project = {   'archived': False,
+    'assigneeType': 'UNASSIGNED',
+    'components': [   {   'description': 'Comp1',
+                          'id': '12392576',
+                          'isAssigneeTypeValid': False,
+                          'name': 'aardvark',
+                          'self': 'https://issues.pie.com/rest/api/2/component/12392576'},
+                      {   'description': 'anteater',
+                          'id': '12392393',
+                          'isAssigneeTypeValid': False,
+                          'name': 'anteater',
+                          'self': 'https://issues.pie.com/rest/api/2/component/12392393'},
+                      {   'description': 'yellow belly',
+                          'id': '12392577',
+                          'isAssigneeTypeValid': False,
+                          'name': 'marmot',
+                          'self': 'https://issues.pie.com/rest/api/2/component/12392577'}],
+    'description': 'The Test Project',
+    'expand': 'description,lead,url,projectKeys',
+    'id': '12336920',
+    'issueTypes': [   {
+                          'description': '',
+                          'iconUrl': 'https://issues.pie.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype',
+                          'id': '20',
+                          'name': 'Bug',
+                          'self': 'https://issues.pie.com/rest/api/2/issuetype/20',
+                          'subtask': False},
+                      {   'avatarId': 13267,
+                          'description': 'Created by Jira Software - do not '
+                                         'edit or delete. Issue type for a big '
+                                         'user story that needs to be broken '
+                                         'down.',
+                          'iconUrl': 'https://issues.pie.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype',
+                          'id': '16',
+                          'name': 'Epic',
+                          'self': 'https://issues.pie.com/rest/api/2/issuetype/16',
+                          'subtask': False},
+                      {   'avatarId': 13275,
+                          'description': 'Created by Jira Software - do not '
+                                         'edit or delete. Issue type for a '
+                                         'user story.',
+                          'iconUrl': 'https://issues.pie.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype',
+                          'id': '17',
+                          'name': 'Story',
+                          'self': 'https://issues.pie.com/rest/api/2/issuetype/17',
+                          'subtask': False},
+                      {   'avatarId': 13278,
+                          'description': 'A task that needs to be done.',
+                          'iconUrl': 'https://issues.pie.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype',
+                          'id': '3',
+                          'name': 'Task',
+                          'self': 'https://issues.pie.com/rest/api/2/issuetype/3',
+                          'subtask': False},
+                      {   'avatarId': 13276,
+                          'description': 'The sub-task of the issue',
+                          'iconUrl': 'https://issues.pie.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype',
+                          'id': '5',
+                          'name': 'Sub-task',
+                          'self': 'https://issues.pie.com/rest/api/2/issuetype/5',
+                          'subtask': True}],
+    'key': 'TEST',
+    'lead': {   'active': True,
+                'displayName': "Pork Chop",
+                'key': 'pchop',
+                'name': 'pchop@pie.com',
+                'self': 'https://issues.pie.com/rest/api/2/user?username=pchop@pie.com'},
+    'name': 'Test Project',
+    'projectCategory': {   'description': 'The Project Category',
+                           'id': '10730',
+                           'name': 'Category',
+                           'self': 'https://issues.pie.com/rest/api/2/projectCategory/10730'},
+    'projectTypeKey': 'software',
+    'versions': [   {   'archived': False,
+                        'description': '1.0',
+                        'id': '12416509',
+                        'name': 'version-1.0',
+                        'overdue': False,
+                        'projectId': 12336920,
+                        'releaseDate': '2032-01-01',
+                        'released': False,
+                        'self': 'https://issues.pie.com/rest/api/2/version/12416509',
+                        'startDate': '2024-01-01',
+                        'userReleaseDate': '2024/06/01',
+                        'userStartDate': '2024/01/01'},
+                    {   'archived': False,
+                        'description': '2.0',
+                        'id': '12416345',
+                        'name': 'version-2.0',
+                        'overdue': False,
+                        'projectId': 12336920,
+                        'releaseDate': '2024-03-05',
+                        'released': False,
+                        'self': 'https://issues.pie.com/rest/api/2/version/12416345',
+                        'startDate': '2023-12-01',
+                        'userReleaseDate': '2024/12/01',
+                        'userStartDate': '2024/12/01'}]
+}
+
+
 class fake_jira_session():
     def __init__(self):
         self.get_urls = []
@@ -496,6 +610,8 @@ class fake_jira_session():
 
     def get(self, url):
         self.get_urls.append(url)
+        if url.endswith('statuses'):
+            return fake_statuses
 
     def post(self, url, data=None):
         self.post_urls[url] = data
@@ -513,12 +629,14 @@ class fake_jira_session():
 class fake_jira(JIRA):
     def __init__(self, **kwargs):
         self._fields_cache_value = {}
+        self.deploymentType = 'Server'
+        self._version = (9, 0, 0)
+        self._options = {'async': False}
+
+    def _get_url(self, url_fragment, **args):
         pass
 
-    def _get_url(self, url_fragment):
-        pass
-
-    def _get_json(self, url_fragment):
+    def _get_json(self, url_fragment, **args):
         pass
 
     def add_simple_link(self, issue, link):
@@ -569,7 +687,10 @@ class fake_jira(JIRA):
         pass
 
     def project(self, project_key):
-        pass
+        ret = Project({'server': 'issues.pie.com', 'rest_path': 'rest/api/2', 'rest_api_version': 2, 'async': False}, None)
+        ret.raw = fake_project
+        dict2resource(fake_project, ret)
+        return ret
 
     def myself(self):
         return fake_user

--- a/jirate/tests/templates/bad-template.yaml
+++ b/jirate/tests/templates/bad-template.yaml
@@ -1,5 +1,5 @@
 issues:
-  - issue_type: "Story"
+  - issuetype: "Story"
     summary: "Set up Jirate templates on my machine"
     # Description terminated by two newlines
     description: |
@@ -19,7 +19,7 @@ issues:
         description: "Description for subtask 2"
       - summary: "Eat a snack as a reward for all my hard work"
         description: "Description for subtask 3"
-  - issue_type: "Story"
+  - issuetype: "Story"
     summery: "Make sure I stop using the default template"
     subtasks:
       - summery: "Obtain or create custom templates"

--- a/jirate/tests/templates/good-template.yaml
+++ b/jirate/tests/templates/good-template.yaml
@@ -1,5 +1,5 @@
 issues:
-  - issue_type: "Story"
+  - issuetype: "Story"
     summary: "Set up Jirate templates on my machine"
     # Description terminated by two newlines
     description: |
@@ -19,7 +19,7 @@ issues:
         description: "Description for subtask 2"
       - summary: "Eat a snack as a reward for all my hard work"
         description: "Description for subtask 3"
-  - issue_type: "Story"
+  - issuetype: "Story"
     summary: "Make sure I stop using the default template"
     description: "People won't appreciate it if I keep filing the same issues over and over again."
     subtasks:

--- a/jirate/tests/test_jira_cli.py
+++ b/jirate/tests/test_jira_cli.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+from jirate.jira_cli import _parse_creation_args
+
+import pytest  # NOQA
+
+
+def test_creation_args_bare():
+    # With no required/reserved/translated fields, input == output
+    issue_data = {'subtasks': {'1': 2}, 'issue_type': 'whatever', 'pork': 'bacon'}
+
+    assert _parse_creation_args(issue_data) == issue_data
+
+
+def test_creation_args_nominal():
+    # Ensure having a translated field and one field that is reserved that
+    # we strip out the reserved field and translate the other one.
+    reserved_fields = ['subtasks']
+    translate_fields = {'issue_type': 'issuetype'}
+
+    issue_data = {'subtasks': {'1': 2}, 'issue_type': 'whatever', 'pork': 'bacon'}
+    expected = {'issuetype': 'whatever', 'pork': 'bacon'}
+
+    assert _parse_creation_args(issue_data, reserved_fields=reserved_fields, translate_fields=translate_fields) == expected
+
+
+def test_creation_args_no_trans():
+    # Ensure having a translated field but no instance of it, we don't add extra info
+    reserved_fields = ['subtasks']
+    translate_fields = {'issue_type': 'issuetype'}
+
+    issue_data = {'subtasks': {'1': 2}, 'pork': 'bacon'}
+    expected = {'pork': 'bacon'}
+
+    assert _parse_creation_args(issue_data, reserved_fields=reserved_fields, translate_fields=translate_fields) == expected
+
+
+def test_creation_args_missing():
+    # Given a missing required field in our issue_data, ensure that we
+    # raise an error.
+    reserved_fields = ['subtasks']
+    translate_fields = {'issue_type': 'issuetype'}
+    required_fields = ['summary']
+
+    issue_data = {'subtasks': {'1': 2}, 'issue_type': 'whatever', 'pork': 'bacon'}
+
+    with pytest.raises(ValueError):
+        assert _parse_creation_args(issue_data, required_fields=required_fields, reserved_fields=reserved_fields, translate_fields=translate_fields)
+
+
+def test_creation_args_required_trans():
+    # Given an untranslated field name in our issue_data, ensure that it is
+    # translated.
+    reserved_fields = ['subtasks']
+    translate_fields = {'issue_type': 'issuetype'}
+    required_fields = ['summary', 'issuetype']
+
+    issue_data = {'subtasks': {'1': 2}, 'issue_type': 'whatever', 'pork': 'bacon', 'summary': 'Summary'}
+    expected = {'issuetype': 'whatever', 'pork': 'bacon', 'summary': 'Summary'}
+
+    assert _parse_creation_args(issue_data, required_fields=required_fields, reserved_fields=reserved_fields, translate_fields=translate_fields) == expected
+
+
+def test_creation_args_required_no_trans():
+    # Given an input with a required field that is translatable but
+    # already in the right format, we don't alter the output.
+    reserved_fields = ['subtasks']
+    translate_fields = {'issue_type': 'issuetype'}
+    required_fields = ['summary', 'issuetype']
+
+    issue_data = {'subtasks': {'1': 2}, 'issuetype': 'whatever', 'pork': 'bacon', 'summary': 'Summary'}
+    expected = {'issuetype': 'whatever', 'pork': 'bacon', 'summary': 'Summary'}
+
+    assert _parse_creation_args(issue_data, required_fields=required_fields, reserved_fields=reserved_fields, translate_fields=translate_fields) == expected
+
+
+def test_creation_args_defaults():
+    # Ensure that when we are provided default inputs, that those are copied
+    # to our output.  Anything in start_vals should not be removed or ignored
+    # if they are in reserved_fields, since start_vals is expected to be
+    # code and issue_data is user input.
+    reserved_fields = ['subtasks']
+    required_fields = ['summary', 'issuetype']
+    start_vals = {'issuetype': 'whatever', 'other': 'value'}
+
+    issue_data = {'subtasks': {'1': 2}, 'pork': 'bacon', 'summary': 'Summary'}
+    expected = {'pork': 'bacon', 'summary': 'Summary', 'issuetype': 'whatever', 'other': 'value'}
+
+    assert _parse_creation_args(issue_data, required_fields=required_fields, reserved_fields=reserved_fields, start_vals=start_vals) == expected
+
+
+def test_creation_args_defaults_no_override():
+    # Ensure that when we are provided default inputs, that those are copied
+    # to our output.  Additionally, when we have a reserved field that is
+    # already provided in the start_vals but then again in issue_data, if
+    # it is a reserved field, it should not be overridden.
+    reserved_fields = ['subtasks', 'issuetype']
+    required_fields = ['summary', 'issuetype']
+    start_vals = {'issuetype': 'whatever', 'other': 'value'}
+
+    issue_data = {'subtasks': {'1': 2}, 'pork': 'bacon', 'summary': 'Summary', 'issuetype': 'other_issuetype'}
+    expected = {'pork': 'bacon', 'summary': 'Summary', 'issuetype': 'whatever', 'other': 'value'}
+
+    assert _parse_creation_args(issue_data, required_fields=required_fields, reserved_fields=reserved_fields, start_vals=start_vals) == expected
+
+
+def test_creation_args_defaults_override():
+    # Ensure that when we are provided default inputs, that those are copied
+    # to our output.  Additionally, when we have a field in our start_vals
+    # that is not reserved and also provided in issue_data, we should
+    # overwrite it.
+    reserved_fields = ['subtasks']
+    required_fields = ['summary', 'issuetype']
+    start_vals = {'issuetype': 'whatever', 'other': 'value'}
+
+    issue_data = {'subtasks': {'1': 2}, 'pork': 'bacon', 'summary': 'Summary', 'issuetype': 'other_issuetype'}
+    expected = {'pork': 'bacon', 'summary': 'Summary', 'issuetype': 'other_issuetype', 'other': 'value'}
+
+    assert _parse_creation_args(issue_data, required_fields=required_fields, reserved_fields=reserved_fields, start_vals=start_vals) == expected

--- a/jirate/tests/test_jira_cli.py
+++ b/jirate/tests/test_jira_cli.py
@@ -169,3 +169,37 @@ def test_create_from_template_customfield():
     assert issue == [{'parent': 'TEST-2'}]
     issue = fake_jirate.issue('TEST-2')
     assert issue == {'key': 'TEST-2', 'raw': {'fields': {'description': 'Test of custom field transmogrify', 'issuetype': 'Task', 'customfield_1234567': 'abc123', 'project': {'key': 'TEST'}, 'summary': 'custom field test'}}}
+
+
+def test_create_from_template_subtasks():
+    # TEST-3/4 pop out because we are reusing the above fake_jirate
+    template = {'issues': [
+                {'summary': 'Sub Tasks Check',
+                 'issuetype': 'Task',
+                 'subtasks': [
+                     {'summary': 'Child Task'}
+                 ]}]}
+
+    _create_from_template(args, template)
+    # Creates TEST-3 and TEST-4
+    assert fake_jirate.issue('TEST-3') == {'key': 'TEST-3', 'raw': {'fields': {'issuetype': 'Task', 'project': {'key': 'TEST'}, 'summary': 'Sub Tasks Check'}}}
+    assert fake_jirate.issue('TEST-4') == {'key': 'TEST-4', 'raw': {'fields': {'issuetype': 'Sub-task', 'parent': 'TEST-3', 'project': {'key': 'TEST'}, 'summary': 'Child Task'}}}
+
+
+def test_create_from_template_multiple_types():
+    # TEST-5/6 pop out because we are reusing the above fake_jirate
+    template = {'issues': [
+                {'summary': 'Multitype1',
+                 'issuetype': 'Task'
+                 },
+                {'summary': 'Multitype2',
+                 'issuetype': 'Bug',
+                 'subtasks': [
+                     {'summary': 'Bug Subtask'}
+                 ]}]}
+
+    _create_from_template(args, template)
+    # Creates TEST-5 and TEST-6
+    assert fake_jirate.issue('TEST-5') == {'key': 'TEST-5', 'raw': {'fields': {'issuetype': 'Task', 'project': {'key': 'TEST'}, 'summary': 'Multitype1'}}}
+    assert fake_jirate.issue('TEST-6') == {'key': 'TEST-6', 'raw': {'fields': {'issuetype': 'Bug', 'project': {'key': 'TEST'}, 'summary': 'Multitype2'}}}
+    assert fake_jirate.issue('TEST-7') == {'key': 'TEST-7', 'raw': {'fields': {'issuetype': 'Sub-task', 'project': {'key': 'TEST'}, 'parent': 'TEST-6', 'summary': 'Bug Subtask'}}}


### PR DESCRIPTION
With this change, you can use any custom field you could use from the CLI within templates using the `nym` or field name. Ex: `story_points`, or `fixversions`