### PR TITLE
jira: Fix get_user()

### DIFF
--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -224,7 +224,7 @@ class Jirate(object):
         if '@' not in username:
             return username
 
-        users = self.jira.search_users(query=username)
+        users = self.jira.search_users(username)
         if len(users) > 1:
             raise ValueError(f'Multiple matching users for \'{username}\'')
         elif not users:


### PR DESCRIPTION
Passing `query=xxx` results in a 400