### PR TITLE
jira: Fix bug in subtask code

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: jirate
-Version: 0.7.0
+Version: 0.7.1
 Summary: Python CLI for JIRA and Trello
 Author: Lon Hohberger
 Author-email: lon@metamorphism.com

--- a/jirate/__init__.py
+++ b/jirate/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/python3
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/jirate/jira_input.py
+++ b/jirate/jira_input.py
@@ -151,7 +151,7 @@ def transmogrify_input(field_definitions, **args):
         metadata in field_definitions
     """
     drop_fields = ['attachment', 'reporter', 'issuelinks']  # These are not set during create/update
-    simple_fields = ['project', 'issuetype', 'summary', 'description', 'parent']                # Don't process these fields at all
+    simple_fields = ['project', 'issuetype', 'summary', 'description']                # Don't process these fields at all
     output = {}
     def_map = {}
 

--- a/jirate/tests/__init__.py
+++ b/jirate/tests/__init__.py
@@ -16,6 +16,12 @@ fake_user = {'self': 'https://domain.com/rest/api/2/user?username=porkchop', 'ke
 
 
 fake_fields = [
+    {'clauseNames': ['parent', 'Parent'],
+        'custom': False,
+        'id': 'parent',
+        'name': 'Parent',
+        'schema': {'system': 'parent', 'type': 'issuelink'}
+     },
     {'clauseNames': ['priority', 'Priority'],
         'custom': False,
         'id': 'priority',

--- a/jirate/tests/test_jira_cli.py
+++ b/jirate/tests/test_jira_cli.py
@@ -183,7 +183,7 @@ def test_create_from_template_subtasks():
     _create_from_template(args, template)
     # Creates TEST-3 and TEST-4
     assert fake_jirate.issue('TEST-3') == {'key': 'TEST-3', 'raw': {'fields': {'issuetype': 'Task', 'project': {'key': 'TEST'}, 'summary': 'Sub Tasks Check'}}}
-    assert fake_jirate.issue('TEST-4') == {'key': 'TEST-4', 'raw': {'fields': {'issuetype': 'Sub-task', 'parent': 'TEST-3', 'project': {'key': 'TEST'}, 'summary': 'Child Task'}}}
+    assert fake_jirate.issue('TEST-4') == {'key': 'TEST-4', 'raw': {'fields': {'issuetype': 'Sub-task', 'parent': {'key': 'TEST-3'}, 'project': {'key': 'TEST'}, 'summary': 'Child Task'}}}
 
 
 def test_create_from_template_multiple_types():
@@ -202,4 +202,4 @@ def test_create_from_template_multiple_types():
     # Creates TEST-5 and TEST-6
     assert fake_jirate.issue('TEST-5') == {'key': 'TEST-5', 'raw': {'fields': {'issuetype': 'Task', 'project': {'key': 'TEST'}, 'summary': 'Multitype1'}}}
     assert fake_jirate.issue('TEST-6') == {'key': 'TEST-6', 'raw': {'fields': {'issuetype': 'Bug', 'project': {'key': 'TEST'}, 'summary': 'Multitype2'}}}
-    assert fake_jirate.issue('TEST-7') == {'key': 'TEST-7', 'raw': {'fields': {'issuetype': 'Sub-task', 'project': {'key': 'TEST'}, 'parent': 'TEST-6', 'summary': 'Bug Subtask'}}}
+    assert fake_jirate.issue('TEST-7') == {'key': 'TEST-7', 'raw': {'fields': {'issuetype': 'Sub-task', 'project': {'key': 'TEST'}, 'parent': {'key': 'TEST-6'}, 'summary': 'Bug Subtask'}}}


### PR DESCRIPTION
Subtask creation requires 'parent': {'key': 'TEST-1'} format.

Creation metadata says issuelink is the type. We were skipping this in create() and tests were incorect as a result.