### PR TITLE
Add field translation functions

### DIFF
--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -84,7 +84,7 @@ def print_issues_by_field(issue_list, args=None):
         row = []
         row.append(issue.key)
         for field in fields:
-            field_key = args.project.field_map(field, issue)
+            field_key = args.project.field_to_id(field)
             if not field_key:
                 row.append('N/A')
                 continue

--- a/jirate/tests/test_jirate.py
+++ b/jirate/tests/test_jirate.py
@@ -107,3 +107,27 @@ def test_transition_bad_field():
     fake_jirate.jira._session.reset()
     with pytest.raises(ValueError):
         assert fake_jirate.move('TEST-1', 'done', beastly_fido='odif_yltsaeb') == [issue]
+
+
+@pytest.mark.parametrize("param,expected", [
+    ('Fixed in Build', 'customfield_1234567'),
+    ('fixed_in_build', 'customfield_1234567'),
+    ('customfield_1234567', 'customfield_1234567')])
+def test_field_to_id(param, expected):
+    assert fake_jirate.field_to_id(param) == expected
+
+
+@pytest.mark.parametrize("param,expected", [
+    ('Fixed in Build', 'fixed_in_build'),
+    ('fixed_in_build', 'fixed_in_build'),
+    ('customfield_1234567', 'fixed_in_build')])
+def test_field_to_alias(param, expected):
+    assert fake_jirate.field_to_alias(param) == expected
+
+
+@pytest.mark.parametrize("param,expected", [
+    ('Fixed in Build', 'Fixed in Build'),
+    ('fixed_in_build', 'Fixed in Build'),
+    ('customfield_1234567', 'Fixed in Build')])
+def test_field_to_human(param, expected):
+    assert fake_jirate.field_to_human(param) == expected


### PR DESCRIPTION
The existing field_map() function was able to translate human-readable names into field IDs. Renamed that to field_to_id() and added similar functions to similarly translate to full names and to aliases as well.

This will make it easier to work with fields when we read user input or write output that humans as supposed to parse easily.