### PR TITLE
Fuzzy values fix

### DIFF
--- a/jirate/tests/__init__.py
+++ b/jirate/tests/__init__.py
@@ -12,12 +12,14 @@ fake_user = {'self': 'https://domain.com/rest/api/2/user?username=porkchop', 'ke
 
 
 fake_fields = [
+    # 0 - parent
     {'clauseNames': ['parent', 'Parent'],
         'custom': False,
         'id': 'parent',
         'name': 'Parent',
         'schema': {'system': 'parent', 'type': 'issuelink'}
      },
+    # 1 - priority
     {'clauseNames': ['priority', 'Priority'],
         'custom': False,
         'id': 'priority',
@@ -40,6 +42,7 @@ fake_fields = [
         'hasDefaultValue': True,
         'operations': ['set']
      },
+    # 2 - description
     {'clauseNames': ['description', 'Description'],
         'custom': False,
         'name': 'Description',
@@ -48,6 +51,7 @@ fake_fields = [
         'operations': ['set'],
         'schema': {'type': 'string'},
      },
+    # 3 - components
     {'clauseNames': ['components', 'Component/s'],
         'custom': False,
         'id': 'components',
@@ -61,7 +65,15 @@ fake_fields = [
             {'id': 1003,
              'name': 'glibc'},
             {'id': 1004,
-             'name': 'porkchop'}],
+             'name': 'porkchop'},
+            {'id': 1005,
+             'name': 'test two'},
+            {'id': 1006,
+             'name': 'test three'},
+            {'id': 1007,
+             'name': 'fuzzy match'},
+            {'id': 1008,
+             'name': 'python 4.0'}],
         'operations': ['add', 'set', 'remove'],
         'required': True
      },

--- a/jirate/tests/test_input.py
+++ b/jirate/tests/test_input.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-from jirate.tests import fake_metadata, fake_transitions
+from jirate.tests import fake_metadata, fake_transitions, fake_fields
 from jirate.jira_input import transmogrify_input
-from jirate.jira_input import check_value
+from jirate.jira_input import check_value, allowed_value_validate
 
 import os
 import time
@@ -151,7 +151,8 @@ def test_trans_metadata():
 def test_check_value_simple():
     valid = {'1': ['1', ' 1', '1 ', '1-', '-1'],
              'a': ['a', ' a', 'a ', 'a-', '-a'],
-             '1.1': [' 1.1', '1.1 ']}
+             '1.1': [' 1.1', '1.1 '],
+             'test': ['test', 'test two']}
 
     for check in valid:
         for value in valid[check]:
@@ -174,3 +175,29 @@ def test_check_value_nomatch():
     for check in valid:
         for value in valid[check]:
             assert(not check_value(check, value))
+
+
+def test_fuzzy_values_exact():
+    allowed_values = fake_fields[3]['allowedValues']  # components
+    # python and 'python 4.0' are available, but because this is exact,
+    # we get only one python result
+    assert allowed_value_validate('components', 'python', allowed_values) == 'python'
+
+
+def test_fuzzy_values_fail():
+    allowed_values = fake_fields[3]['allowedValues']  # components
+    # 2 possible matches for 'test', so ambiguous, raise valueerror
+    with pytest.raises(ValueError):
+        allowed_value_validate('components', 'test', allowed_values)
+
+
+def test_fuzzy_values_approx():
+    allowed_values = fake_fields[3]['allowedValues']  # components
+    # only one match for this
+    assert allowed_value_validate('components', 'fuzzy', allowed_values) == 'fuzzy match'
+
+
+def test_avv_multiple():
+    allowed_values = fake_fields[3]['allowedValues']  # components
+
+    assert allowed_value_validate('components', ['fuzzy', 'python'], allowed_values) == ['fuzzy match', 'python']

--- a/jirate/tests/test_input.py
+++ b/jirate/tests/test_input.py
@@ -158,6 +158,14 @@ def test_check_value_simple():
             assert(check_value(check, value))
 
 
+def test_check_value_exact():
+    assert(check_value('1', '1') == 2)
+
+
+def test_check_value_inexact():
+    assert(check_value('1', '1 ') == 1)
+
+
 def test_check_value_nomatch():
     valid = {'1': ['a1', ' 12', '1.1'],
              'a': ['a1', ' ab', 'a.b'],
@@ -165,4 +173,4 @@ def test_check_value_nomatch():
 
     for check in valid:
         for value in valid[check]:
-            assert(check_value(check, value) is False)
+            assert(not check_value(check, value))


### PR DESCRIPTION
This makes fuzzy value usage more precise. Previously, if >1 match happened when something matched exactly, we would fail with ValueError. This PR:

- Makes exact matches preempt fuzzy matches
- Ensures output list order matches input list order
- Improves tests around all of this