### PR TITLE
jira: Truncate field headers

### DIFF
--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -88,7 +88,7 @@ def print_issues_by_field(issue_list, args=None):
     fields = parse_field_widths(args.fields, ignore_fields=['key'], starting_fields=fields)
 
     output = []
-    output.append(list(fields.keys()))
+    output.append(list(truncate(key, fields[key]) for key in fields))
     del fields['key']
 
     found_fields = []


### PR DESCRIPTION
When truncating fields, we were preserving the full width of the field name but truncating the field values.  For example, one could end up like so if using "issuetype:5,summary" as the fields option:

  key    | issuetype | summary
  TEST-1 | Feat…     | whatever

This makes it:

  key    | issu… | summary
  TEST-1 | Feat… | whatever