### PR TITLE
jira: Allow combining a named search with raw cli

### DIFF
--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -196,6 +196,10 @@ def search_jira(args):
             print(f'No search configured: {named}')
             return (1, False)
         search_query = searches[named]
+        if args.text:
+            additional = ' '.join(args.text)
+            search_query = f'({additional}) AND {search_query}'
+            print(search_query)
         ret = args.project.search_issues(search_query)
     else:
         search_query = ' '.join(args.text)


### PR DESCRIPTION
Sometimes, you have hundreds of issues to go through but want to prune that list a bit.  For example:

  $ jirate search -n mysearch 'summary ~ pork'

This change prepends the named search with additional text, allowing flexibility, like so:

  (additional seach things) AND [mysearch]