### PR TITLE
(dirty) Allow sprint setting by ID

### DIFF
--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -548,6 +548,10 @@ def create_from_template(args):
         print(f"Provided template file is not valid: {args.template_file}")
         raise e
 
+    if args.dry_run:
+        print(template_output)
+        return (0, True)
+
     all_filed = _create_from_template(args, template)
 
     # Need to refresh to that issues get re-fetched to include subtasks
@@ -1303,6 +1307,7 @@ def create_parser():
     cmd.add_argument('template_file', help='Path to the template file')
     cmd.add_argument('-n', '--non-interactive', default=False, help='Do not prompt for variables', action='store_true')
     cmd.add_argument('-q', '--quiet', default=False, help='Only print new issue IDs after creation (for scripting)', action='store_true')
+    cmd.add_argument('--dry-run', default=False, help='Print template with variables substituted; do not file issues', action='store_true')
     cmd.add_argument('vars', help='Variables/values (name value name2 value2 ...)', nargs='*')
 
     cmd = parser.command('validate', help='Validate a YAML template for use with the "template" command',

--- a/jirate/jira_input.py
+++ b/jirate/jira_input.py
@@ -161,6 +161,9 @@ def transmogrify_value(value, field_info):
     av = field_info['allowedValues'] if 'allowedValues' in field_info else None
 
     if schema['type'] == 'array':
+        # Patch for Jira sprint - TODO: make more generic
+        if 'custom' in schema and schema['custom'] == "com.pyxis.greenhopper.jira:gh-sprint":
+            return in_number(value)
         vals = allowed_value_validate(field_info['name'], parse_params(value), av)
         try:
             ret = _input_array_renderers[schema['items']](vals)


### PR DESCRIPTION
The Jira REST APIs for sprints are an entirely different API tree (/rest/sprint/1.0 vs /rest/api/latest/...).

Until a major feature is added to support the new API tree and using it properly, this can be used as a quick and dirty way to add an issue to a sprint, i.e.:

   $ jirate field MYKEY-123 set sprint 12345

Unfortunately, there's no way to set via "name".