### PR TITLE
Fix block quote handling

### DIFF
--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -736,8 +736,10 @@ def _str_presenter(dumper, data):
     """
     Makes PyYAML print multiline strings in a sensible way
     """
-    if data.count('\n') > 0:
-        data = data.replace('\r\n', '\n')  # CRLFs confuse and anger PyYAML
+    data = data.rstrip()
+    lines = data.splitlines()
+    if len(lines) > 1:
+        data = '\n'.join([line.rstrip() for line in lines])
         return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
     return dumper.represent_scalar('tag:yaml.org,2002:str', data)
 


### PR DESCRIPTION
When generating a template from an issue, if a line in the description of the issue or a subtask had a trailing space, python yaml would encode the whole thing as a quoted string instead of a block-quote like it should have been.

By iterating through the text and stripping off trailing whitespace, first on the whole, then on each line individually, this issue is resolved.

Related to: https://github.com/yaml/pyyaml/issues/121

Found / original patch by Jon Schlueter @yazug 