### PR TITLE
jira: Add internal rendering for some custom fields

### DIFF
--- a/jirate/jira_custom.py
+++ b/jirate/jira_custom.py
@@ -4,9 +4,9 @@ import re
 
 
 _val_to_py = {
-        'false': False,
-        'true': True,
-        '<null>': None
+    'false': False,
+    'true': True,
+    '<null>': None
 }
 
 
@@ -65,7 +65,18 @@ def sprint_field(data, fields, as_object=False):
     return f"{sprint['name']} (ID: {sprint['id']})"
 
 
+def no_display(data, fields, as_object=False):
+    if as_object:
+        return data
+    return None
+
+
 # Used by jira_fields
 custom_field_renderers = {
-        'com.pyxis.greenhopper.jira:gh-sprint': sprint_field
+    'com.atlassian.jira.plugins.jira-development-integration-plugin:devsummary': no_display,
+    'com.onresolve.jira.groovy.groovyrunner:scripted-field': no_display,
+    'com.pyxis.greenhopper.jira:gh-epic-color': no_display,
+    'com.pyxis.greenhopper.jira:gh-global-rank': no_display,
+    'com.pyxis.greenhopper.jira:gh-lexo-rank': no_display,
+    'com.pyxis.greenhopper.jira:gh-sprint': sprint_field
 }

--- a/jirate/jira_custom.py
+++ b/jirate/jira_custom.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+
+import re
+
+
+_val_to_py = {
+        'false': False,
+        'true': True,
+        '<null>': None
+}
+
+
+def val_to_py(val):
+    if val in _val_to_py:
+        return _val_to_py[val]
+    try:
+        ret = int(val)
+        return ret
+    except ValueError:
+        pass
+    try:
+        ret = float(val)
+        return ret
+    except ValueError:
+        pass
+    return val
+
+
+# Jira Sprint Rendering
+# TODO: Allow custom sprint output
+def sprint_content_to_py(sprint_info):
+    ret = []
+    if isinstance(sprint_info, str):
+        sprint_info = [sprint_info]
+
+    for sprint in sprint_info:
+        match = re.match(r'com.atlassian.greenhopper.service.sprint.Sprint@([a-z0-9]+)\[([^\]]+)\]', sprint)
+        if not match:
+            raise ValueError(f'Could not parse sprint: {sprint}')
+
+        item = {'_hash': str(match.group(1))}
+        info_bits = match.group(2)
+        for bit in info_bits.split(','):
+            key, value = bit.split('=')
+            item[key] = val_to_py(value)
+        ret.append(item)
+    return ret
+
+
+def sprint_field(data, fields, as_object=False):
+    if as_object:
+        return data
+    sprints = sprint_content_to_py(data)
+    active_sprints = []
+    for sprint in sprints:
+        if sprint['state'] == 'ACTIVE':
+            active_sprints.append(f"{sprint['name']} (ID: {sprint['id']})")
+
+    if active_sprints:
+        # All active sprints
+        return ', '.join(active_sprints)
+
+    # Last closed sprint
+    sprint = sprints[-1]
+    return f"{sprint['name']} (ID: {sprint['id']})"
+
+
+# Used by jira_fields
+custom_field_renderers = {
+        'com.pyxis.greenhopper.jira:gh-sprint': sprint_field
+}

--- a/jirate/jira_fields.py
+++ b/jirate/jira_fields.py
@@ -3,6 +3,7 @@
 import re  # NOQA
 from collections import OrderedDict
 from jirate.decor import pretty_date, vsep_print, comma_separated
+from jirate.jira_custom import custom_field_renderers
 
 
 #
@@ -371,6 +372,9 @@ _array_renderers = {
 
 def apply_schema_renderer(field):
     schema = field['schema']
+    if 'custom' in schema and schema['custom'] in custom_field_renderers:
+        field['display'] = custom_field_renderers[schema['custom']]
+        return
     if schema['type'] == 'array':
         try:
             field['display'] = _array_renderers[schema['items']]

--- a/jirate/tests/test_jira_custom.py
+++ b/jirate/tests/test_jira_custom.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+from jirate.jira_custom import sprint_content_to_py, sprint_field
+
+import pytest  # NOQA
+
+
+def test_jira_sprint_parse_simple():
+    val1 = "com.atlassian.greenhopper.service.sprint.Sprint@49e59daf[id=13133,rapidViewId=21164,state=CLOSED,name=Porky Sprint 5 - Sept,startDate=2024-09-01T06:22:00.000Z,endDate=2024-09-29T06:22:00.000Z,completeDate=2024-10-02T06:38:15.491Z,activatedDate=2024-09-03T02:47:34.778Z,sequence=13133,goal=,synced=false,autoStartStop=false,incompleteIssuesDestinationId=<null>]"
+
+    expected = [{'_hash': '49e59daf',
+                 'id': 13133,
+                 'rapidViewId': 21164,
+                 'state': 'CLOSED',
+                 'startDate': '2024-09-01T06:22:00.000Z',
+                 'endDate': '2024-09-29T06:22:00.000Z',
+                 'completeDate': '2024-10-02T06:38:15.491Z',
+                 'name': 'Porky Sprint 5 - Sept',
+                 'activatedDate': '2024-09-03T02:47:34.778Z',
+                 'sequence': 13133,
+                 'goal': '',
+                 'synced': False,
+                 'autoStartStop': False,
+                 'incompleteIssuesDestinationId': None}]
+
+    assert sprint_content_to_py(val1) == expected
+
+
+def test_sprint_field():
+    val1 = "com.atlassian.greenhopper.service.sprint.Sprint@49e59daf[id=13133,rapidViewId=21164,state=CLOSED,name=Porky Sprint 5 - Sept,startDate=2024-09-01T06:22:00.000Z,endDate=2024-09-29T06:22:00.000Z,completeDate=2024-10-02T06:38:15.491Z,activatedDate=2024-09-03T02:47:34.778Z,sequence=13133,goal=,synced=false,autoStartStop=false,incompleteIssuesDestinationId=<null>]"
+
+    assert sprint_field(val1, None, False) == 'Porky Sprint 5 - Sept (ID: 13133)'
+
+
+def test_sprint_multi_open():
+    # Take last active sprint
+    val1 = ["com.atlassian.greenhopper.service.sprint.Sprint@56814b6f[id=21301,rapidViewId=21064,state=CLOSED,name=Homies Sprint 5,startDate=2025-01-06T03:00:00.000Z,endDate=2025-01-25T04:00:00.000Z,completeDate=2025-01-25T04:00:43.237Z,activatedDate=2025-01-06T03:00:45.655Z,sequence=21301,goal=<null>,synced=false,autoStartStop=true,incompleteIssuesDestinationId=18234]", "com.atlassian.greenhopper.service.sprint.Sprint@638afb2[id=18234,rapidViewId=21064,state=ACTIVE,name=Homies Sprint 6,startDate=2025-01-27T03:00:00.000Z,endDate=2025-02-15T03:00:00.000Z,completeDate=<null>,activatedDate=2025-01-27T03:00:31.194Z,sequence=18234,goal=<null>,synced=false,autoStartStop=true,incompleteIssuesDestinationId=40133]"]
+
+    assert sprint_field(val1, None, False) == 'Homies Sprint 6 (ID: 18234)'
+
+
+def test_sprint_multi_closed():
+    # Take last closed sprint
+    val1 = ["com.atlassian.greenhopper.service.sprint.Sprint@56814b6f[id=21301,rapidViewId=21064,state=CLOSED,name=Homies Sprint 5,startDate=2025-01-06T03:00:00.000Z,endDate=2025-01-25T04:00:00.000Z,completeDate=2025-01-25T04:00:43.237Z,activatedDate=2025-01-06T03:00:45.655Z,sequence=21301,goal=<null>,synced=false,autoStartStop=true,incompleteIssuesDestinationId=18234]", "com.atlassian.greenhopper.service.sprint.Sprint@638afb2[id=18234,rapidViewId=21064,state=CLOSED,name=Homies Sprint 6,startDate=2025-01-27T03:00:00.000Z,endDate=2025-02-15T03:00:00.000Z,completeDate=<null>,activatedDate=2025-01-27T03:00:31.194Z,sequence=18234,goal=<null>,synced=false,autoStartStop=true,incompleteIssuesDestinationId=40133]"]
+
+    assert sprint_field(val1, None, False) == 'Homies Sprint 6 (ID: 18234)'
+
+
+def test_sprint_multi_future():
+    # Take last active sprint
+    val1 = ["com.atlassian.greenhopper.service.sprint.Sprint@56814b6f[id=21301,rapidViewId=21064,state=ACTIVE,name=Homies Sprint 5,startDate=2025-01-06T03:00:00.000Z,endDate=2025-01-25T04:00:00.000Z,completeDate=2025-01-25T04:00:43.237Z,activatedDate=2025-01-06T03:00:45.655Z,sequence=21301,goal=<null>,synced=false,autoStartStop=true,incompleteIssuesDestinationId=18234]", "com.atlassian.greenhopper.service.sprint.Sprint@638afb2[id=18234,rapidViewId=21064,state=FUTURE,name=Homies Sprint 6,startDate=2025-01-27T03:00:00.000Z,endDate=2025-02-15T03:00:00.000Z,completeDate=<null>,activatedDate=2025-01-27T03:00:31.194Z,sequence=18234,goal=<null>,synced=false,autoStartStop=true,incompleteIssuesDestinationId=40133]"]
+
+    assert sprint_field(val1, None, False) == 'Homies Sprint 5 (ID: 21301)'
+
+
+def test_sprint_multi_active():
+    # two sprints, I guess?
+    val1 = ["com.atlassian.greenhopper.service.sprint.Sprint@56814b6f[id=21301,rapidViewId=21064,state=ACTIVE,name=Homies Sprint 5,startDate=2025-01-06T03:00:00.000Z,endDate=2025-01-25T04:00:00.000Z,completeDate=2025-01-25T04:00:43.237Z,activatedDate=2025-01-06T03:00:45.655Z,sequence=21301,goal=<null>,synced=false,autoStartStop=true,incompleteIssuesDestinationId=18234]", "com.atlassian.greenhopper.service.sprint.Sprint@638afb2[id=18234,rapidViewId=21064,state=ACTIVE,name=Homies Sprint 6,startDate=2025-01-27T03:00:00.000Z,endDate=2025-02-15T03:00:00.000Z,completeDate=<null>,activatedDate=2025-01-27T03:00:31.194Z,sequence=18234,goal=<null>,synced=false,autoStartStop=true,incompleteIssuesDestinationId=40133]"]
+
+    assert sprint_field(val1, None, False) == 'Homies Sprint 5 (ID: 21301), Homies Sprint 6 (ID: 18234)'


### PR DESCRIPTION
- Render sprints by parsing the data
- Disable rendering of several field categories for now. Note that users' configuration overrides for how to display these fields, if present, are preserved.