### PR TITLE
Fix fixversions search

### DIFF
--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -215,16 +215,24 @@ class Jirate(object):
             return self._field_to_human[id_or_alias]
         return None
 
+    def _builtin_map_init(self, jira_val, human_val):
+        self._field_to_id[jira_val] = jira_val
+        self._field_to_id[human_val] = jira_val
+        self._field_to_alias[jira_val] = jira_val
+        self._field_to_alias[human_val] = jira_val
+        self._field_to_human[jira_val] = human_val
+        self._field_to_human[human_val] = human_val
+
     def _field_map_init(self):
         # For inscrutable reasons Jira returns all possible fields via the /field API...
         # ...all but one: the "parent" field. We hardcode the translation so higher-level
         # code doesn't need to deal with that.
-        self._field_to_id = {"parent": "parent",
-                             "Parent": "parent"}
-        self._field_to_alias = {"parent": "parent",
-                                "Parent": "parent"}
-        self._field_to_human = {"parent": "Parent",
-                                "Parent": "Parent"}
+        self._field_to_id = {}
+        self._field_to_alias = {}
+        self._field_to_human = {}
+        self._builtin_map_init('parent', 'Parent')
+        self._builtin_map_init('fixVersions', 'fixversions')
+
         fields = self.jira.fields()
         for field in fields:
             field_id = field['id']

--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -232,6 +232,7 @@ class Jirate(object):
         self._field_to_human = {}
         self._builtin_map_init('parent', 'Parent')
         self._builtin_map_init('fixVersions', 'fixversions')
+        self._builtin_map_init('lastViewed', 'lastviewed')
 
         fields = self.jira.fields()
         for field in fields:

--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -35,7 +35,7 @@ def _user_fix(obj, *args):
     try:
         ret = JIRA.user(obj, *args)
         return ret
-    except JIRAError as err:
+    except JIRAError:
         # There's no check by key; try it
         pass
 

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -327,10 +327,17 @@ def search_jira(args):
     stripped = []
     if args.prune_regex:
         field = args.prune_regex[0]
+        fid = args.project.field_to_id(field)
         regex = args.prune_regex[1]
-
         for issue in ret:
             val = issue.field(field)
+            try:
+                if val and re.search(regex, val):
+                    stripped.append(issue)
+                continue
+            except TypeError:
+                pass
+            (_, val) = render_field_data(fid, issue.raw['fields'], False, args.project.allow_code)
             if val and re.search(regex, val):
                 stripped.append(issue)
         ret = stripped


### PR DESCRIPTION
Also resolves using fixversions in fields output.

fixversions and lastviewed are internal JIRA fields which have camel case naming, so we need to alias them or else searching by field or displaying by field would require ensuring we type in the Jira field value instead of an alias since they are not returned in /field