### PR TITLE
Started as a minimal update, but now has maximal updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Each field in `custom_fields` is a dictionary. Jirate only cares about a few fie
 - `disabled` (Optional) - If set to `true`, do not allow rendering of this field, even if requested
 - `verbose` (Optional) - If set to `true`, only display this field when someone requests verbose output or requests this field explicitly
 - `code` (Optional) - when `here_there_be_dragons` is set to true, insert a snippet of Python code to render your data.  The field is passed to your one-line of code as `field`; all fields in the issue are passed in as `fields`.  You'll need to know the custom field ID of any field you are trying to reference.
--- `code` can also be: `#~/filename.py:function_name`. If defined in this way, `~/filename.py` should contain `def function_name(field, fields)` in it. `field` is the raw value of the current field being processed, and `fields` are all fields in the issue JSON.
+  - `code` can also be something like: `#~/filename.py:function_name`. If defined in this way, `~/filename.py` should contain `def function_name(field, fields)` in it. `field` is the raw value of the current field being processed, and `fields` is the JSON data for all fields in the issue.
 
 ## Operation
 - Trello support is somewhat unmaintained as the maintainers do not have access to a commercial Trello instance any longer. Taking patches.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Configuration is a JSON document stored as `~/.jirate.json` - an example can be 
 - `proxies` (Optional) - HTTP and/or HTTPS proxies to use
 - `cache_expire` (Optional) - Number of seconds to cache certain JIRA configuration data locally (default: `300`; `0` means no expiration)
 - `cache_file` (Optional) - Where to store cached JIRA configuration data (default: `~/.jirate.cache`)
+- `fancy_output` (Optional) - If set to true, render some things as links and enable per-line visual separation for tables
+- `color_shift` (Optional) - Tune color separation when using `fancy_output`. (0..128; default=16)
 
 ### JIRA Custom field display configuration
 Each field in `custom_fields` is a dictionary. Jirate only cares about a few fields when defining custom rendering; most fields it automatically discerns by asking the server for the `/field` data:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Each field in `custom_fields` is a dictionary. Jirate only cares about a few fie
 - `disabled` (Optional) - If set to `true`, do not allow rendering of this field, even if requested
 - `verbose` (Optional) - If set to `true`, only display this field when someone requests verbose output or requests this field explicitly
 - `code` (Optional) - when `here_there_be_dragons` is set to true, insert a snippet of Python code to render your data.  The field is passed to your one-line of code as `field`; all fields in the issue are passed in as `fields`.  You'll need to know the custom field ID of any field you are trying to reference.
+-- `code` can also be: `#~/filename.py:function_name`. If defined in this way, `~/filename.py` should contain `def function_name(field, fields)` in it. `field` is the raw value of the current field being processed, and `fields` are all fields in the issue JSON.
 
 ## Operation
 - Trello support is somewhat unmaintained as the maintainers do not have access to a commercial Trello instance any longer. Taking patches.

--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -375,6 +375,8 @@ def vsep_print(linesplit=None, screen_width=0, *vals):
 def get_colors():
     if not fancy_output:
         return None
+    if not color_shift:
+        return None
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         return None
     curr_attrs = termios.tcgetattr(sys.stdin)
@@ -428,6 +430,13 @@ def set_color(fg=None, bg=None, erase=False):
 def pretty_matrix(matrix, header=True, header_bar=True):
     global color_shift
 
+    # Range test color_shift
+    if not isinstance(color_shift, int):
+        color_shift = 0
+    if color_shift > 128 or color_shift < 0:
+        color_shift = 0
+
+    colors = None
     if colors := get_colors():
         bgcolor = colors[1]
         tint = [0] * len(bgcolor)

--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
     pass
 
 fancy_output = False
+color_shift = 16
 HILIGHT = '[1m'
 NORMAL = '[0m'
 
@@ -424,14 +425,15 @@ def set_color(fg=None, bg=None, erase=False):
 
 
 def pretty_matrix(matrix, header=True, header_bar=True):
+    global color_shift
     if colors := get_colors():
         bgcolor = colors[1]
         tint = [0] * len(bgcolor)
         for idx in range(0, len(bgcolor)):
-            if bgcolor[idx] >= 240:
-                tint[idx] = bgcolor[idx] - 16
+            if bgcolor[idx] >= ((1 << 8) - color_shift):
+                tint[idx] = bgcolor[idx] - color_shift
             else:
-                tint[idx] = bgcolor[idx] + 16
+                tint[idx] = bgcolor[idx] + color_shift
 
     # total # of printed lines less header
     lines = 0

--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -422,7 +422,7 @@ def set_color(fg=None, bg=None, erase=False):
         # it - that's why we have the erase parameter.
         sys.stdout.write(f'[48;2;{bg[0]};{bg[1]};{bg[2]}m')
         if erase:
-            sys.stdout.write('[2K')
+            sys.stdout.write('[K[2K')
 
 
 def pretty_matrix(matrix, header=True, header_bar=True):

--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -376,6 +376,8 @@ def vsep_print(linesplit=None, screen_width=0, *vals):
 def get_colors():
     if not fancy_output:
         return None
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        return None
     curr_attrs = termios.tcgetattr(sys.stdin)
     new_attrs = copy.deepcopy(curr_attrs)
     new_attrs[3] = curr_attrs[3] & ~(termios.ICANON | termios.ECHO)

--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -6,7 +6,6 @@
 import copy
 import csv
 import re
-import shutil
 import sys
 import termios
 
@@ -285,7 +284,7 @@ def vsep_print(linesplit=None, screen_width=0, *vals):
     consumed = 0
 
     if not screen_width:
-        screen_width = shutil.get_terminal_size()[0]
+        screen_width = termios.tcgetwinsize(sys.stdout)[1]
     args = list(vals)
 
     if not args:
@@ -428,6 +427,7 @@ def set_color(fg=None, bg=None, erase=False):
 
 def pretty_matrix(matrix, header=True, header_bar=True):
     global color_shift
+
     if colors := get_colors():
         bgcolor = colors[1]
         tint = [0] * len(bgcolor)
@@ -440,7 +440,7 @@ def pretty_matrix(matrix, header=True, header_bar=True):
     # total # of printed lines less header
     lines = 0
     even = False
-    screen_width = shutil.get_terminal_size()[0]
+    screen_width = termios.tcgetwinsize(sys.stdout)[1]
     # Renders a table with the right-most field truncated/wrapped if needed.
     # Undefined if the screen width is too wide to accommodate all but the
     # last field

--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -114,15 +114,23 @@ def color_string(string, color=None, bgcolor=None):
     return ret
 
 
+def link_string(text, url):
+    global fancy_output
+    if not fancy_output:
+        return None
+
+    ret = EscapedString(text)
+    ret.update(f']8;;{url}\\{text}]8;;\\')
+    return ret
+
+
 def issue_link_string(issue_key, baseurl=None):
     global fancy_output
 
     if not baseurl or not fancy_output:
         return issue_key
 
-    ret = EscapedString(issue_key)
-    ret.update(f']8;;{baseurl}/browse/{issue_key}\\{issue_key}]8;;\\')
-    return ret
+    return link_string(issue_key, f'{baseurl}/browse/{issue_key}')
 
 
 def parse_params(arg):

--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -352,9 +352,10 @@ class Jirate(object):
         Returns:
           username (string)
         """
-        if '@' not in username:
-            return username
-
+        if username.lower == 'none':
+            return None
+        if username == 'me':
+            return self.user['name']
         users = self.jira.search_users(username)
         if len(users) > 1:
             raise ValueError(f'Multiple matching users for \'{username}\'')
@@ -395,12 +396,9 @@ class Jirate(object):
             # first is assignee
             if users:
                 for user in users:
-                    if user == 'me':
-                        user = self.user['name']
-                    if user == 'none':
-                        user_ids.append(None)
-                    if user not in user_ids:
-                        user_ids.append(self.get_user(user))
+                    uid = self.get_user(user)
+                    if uid not in user_ids:
+                        user_ids.append(uid)
             else:
                 # Just me
                 user = self.user['name']
@@ -972,17 +970,10 @@ class JiraProject(Jirate):
         else:
             project_selector = f'PROJECT = {self.project_name} AND '
 
-        if userid in (None, 'none'):
+        userid = self.get_user(userid)
+        if userid is None:
             assignee_selection = 'assignee is EMPTY'
         else:
-            if userid == 'me':
-                userid = self.user['name']
-            elif '@' in userid:
-                users = self.search_users(userid)
-                if len(users) > 1:
-                    raise ValueError(f'Ambiguous username: {userid}')
-                userid = users[0].name
-
             assignee_selection = f'assignee = "{userid}"'
 
         if status:

--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -62,9 +62,7 @@ def _update_field(issue, field_name_human, value_human, operation='set', fields=
         # TODO use native python-jira issue.fields instead of raw json
         # (Except operations are not captured, which we need)
         fields = issue._jirate.fields(issue.key)
-    if isinstance(value_human, list):
-        value_human = ' '.join(value_human)
-    else:
+    if not isinstance(value_human, list):
         value_human = str(value_human)
 
     # TODO multi-field sets?

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -133,8 +133,10 @@ def print_issues_by_field(issue_list, args=None, exclude_fields=[]):
     fields = parse_field_widths(args.fields, ignore_fields=ignore_fields, starting_fields=fields)
     if args.format != 'csv':
         subtask_prefix = EscapedString('↳ ')
+        subtask_error = EscapedString('‼ ')
     else:
         subtask_prefix = EscapedString('')
+        subtask_error = EscapedString('')
 
     if not args.compact:
         args.compact = args.project.get_user_data('compact_output')
@@ -162,7 +164,10 @@ def print_issues_by_field(issue_list, args=None, exclude_fields=[]):
         # to show this is associated with the above non-Subtask
         if str(issue.fields.issuetype) == _subtask and str(issue.fields.parent) in issue_keys:
             # No f-magic for EscapedString, so we must concatenate
-            key_string = subtask_prefix + key_string
+            if issue.raw['fields']['status']['statusCategory']['name'] != 'Done' and issue.raw['fields']['parent']['fields']['status']['statusCategory']['name'] == 'Done':
+                key_string = subtask_error + key_string
+            else:
+                key_string = subtask_prefix + key_string
         row.append(key_string)
         for field in fields:
             # See if it's a user-defined one first, as optimization

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -18,7 +18,7 @@ import jsonschema
 from jirate.args import ComplicatedArgs, GenericArgs
 from jirate.jboard import JiraProject, get_jira
 from jirate.decor import md_print, pretty_date, hbar_under, hbar, hbar_over, nym, vsep_print, parse_params, truncate, render_matrix, comma_separated
-from jirate.decor import issue_link_string
+from jirate.decor import issue_link_string, link_string
 from jirate.decor import pretty_print  # NOQA
 from jirate.decor import EscapedString
 from jirate.config import get_config, yaml_dump
@@ -1038,12 +1038,16 @@ def print_issue_links(issue, baseurl=None):
 def print_remote_links(links):
     hbar_under('External Links')
     matrix = []
+    fancy = False
     for link in links:
         # color_string throws off length calculations
-        text = link.raw['object']['title']
         lid = str(link.raw['id'])
+        text = link.raw['object']['title']
         url = link.raw['object']['url']
-        matrix.append([lid, text, url])
+        if ret := link_string(text, url):
+            matrix.append([lid, ret])
+        else:
+            matrix.append([lid, text, url])
     render_matrix(matrix, False, False)
     print()
 

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -997,18 +997,6 @@ def display_comment(action, verbose, no_format):
     print()
 
 
-def display_attachment(attachment, verbose):
-    print('  ' + attachment['name'])
-    if verbose:
-        print('    ID:', attachment['id'])
-    if attachment['isUpload']:
-        if attachment['filename'] != attachment['name']:
-            print('    Filename:', attachment['filename'])
-    else:
-        if attachment['url'] != attachment['name']:
-            print('    URL:', attachment['url'])
-
-
 def print_labels(issue, prefix='Labels: '):
     if 'labels' in issue and len(issue['labels']):
         print(prefix, end='')
@@ -1038,7 +1026,6 @@ def print_issue_links(issue, baseurl=None):
 def print_remote_links(links):
     hbar_under('External Links')
     matrix = []
-    fancy = False
     for link in links:
         # color_string throws off length calculations
         lid = str(link.raw['id'])
@@ -1048,6 +1035,22 @@ def print_remote_links(links):
             matrix.append([lid, ret])
         else:
             matrix.append([lid, text, url])
+    render_matrix(matrix, False, False)
+    print()
+
+
+def print_attachments(attachments):
+    hbar_under('Attachments')
+    matrix = []
+    for attachment in attachments:
+        # color_string throws off length calculations
+        aid = str(attachment['id'])
+        text = attachment['filename']
+        url = attachment['content']
+        if ret := link_string(text, url):
+            matrix.append([aid, ret])
+        else:
+            matrix.append([aid, text, url])
     render_matrix(matrix, False, False)
     print()
 
@@ -1127,6 +1130,9 @@ def print_issue(project, issue_obj, verbose=False, no_comments=False, no_format=
         links = project.remote_links(issue_obj)
         if links:
             print_remote_links(links)
+
+        if 'attachment' in issue and len(issue['attachment']):
+            print_attachments(issue['attachment'])
 
     if 'subtasks' in issue and len(issue['subtasks']):
         print_subtasks(issue, project.jira.server_url)

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -1631,11 +1631,12 @@ def main():
     try:
         project = get_jira_project(ns.project, config_file=ns.config, field=field)
     except KeyError:
+        print('Configuration faile failed to parse correctly')
         sys.exit(1)
     except FileNotFoundError:
         print('Please create a configuration file (~/.jirate.json)')
         sys.exit(1)
-    except JIRAError as err:
+    except Exception as err:
         print(err)
         sys.exit(1)
 
@@ -1647,6 +1648,9 @@ def main():
         print(err)
         if ns.debug:
             project.request_cache.debug_dump()
+        sys.exit(1)
+    except Exception as err:
+        print(err)
         sys.exit(1)
     if rc:
         ret = rc[0]

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -1407,6 +1407,8 @@ def get_jira_project(project=None, config=None, config_file=None, **kwargs):
     if 'fancy_output' in jconfig and jconfig['fancy_output']:
         import jirate.decor  # NOQA
         jirate.decor.fancy_output = True
+        if 'color_shift' in jconfig:
+            jirate.decor.color_shift = int(jconfig['color_shift'])
 
     if not project:
         # Not sure why I used an array here

--- a/jirate/jira_fields.py
+++ b/jirate/jira_fields.py
@@ -581,11 +581,10 @@ def field_ordering():
 
 
 def max_field_width(issue, verbose, allow_code):
+    global _fields
     width = 0
 
     for field_key in _fields:
-        if field_key not in issue:
-            continue
         field_name, val = render_field_data(field_key, issue, verbose, allow_code)
         if not val:
             continue

--- a/jirate/jira_fields.py
+++ b/jirate/jira_fields.py
@@ -462,6 +462,8 @@ def apply_field_renderers(custom_field_defs=None, reorder_custom=True):
 
     # reorder
     for field in custom_field_defs:
+        if 'id' not in field:
+            continue
         if field['id'] in _ignore_fields:
             continue
         if field['id'] in base_fields:

--- a/jirate/rqcache.py
+++ b/jirate/rqcache.py
@@ -34,6 +34,7 @@ default_cache_expire = 300
 default_cache_patterns = {
     'GET': [r'/rest/api/[0-9]+/myself$',
             r'/rest/api/[0-9]+/field$',
+            r'/rest/api/[0-9]+/user/search',
             r'/rest/agile/[0-9]+(\.[0-9]+)?/board$',
             r'/rest/agile/[0-9]+(\.[0-9]+)?/board/[0-9]+/sprint$',
             r'/rest/api/[0-9]+/project/[A-Z]+/statuses$',


### PR DESCRIPTION
- Give visual separation between lines in drawn matrices when `fancy_output` is turned on, but let users configure it if they do not like it
- Display attachment information in verbose mode when viewing issues
- When a field or operation expects a user, try really hard to resolve the username for the user.
- Don't assume users with @ is an email address - it's possible to have an email address and a username that looks like an email address but have them be different.
- Be better about printing exceptions when things fail
- Don't always join content when updating fields - some field updates expect arrays
- When listing lots of subtasks and their parents, indicate visually if a parent task is closed while a subtask is not