### PR TITLE
More comprehensive field configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Configuration is a JSON document stored as `~/.jirate.json` - an example can be 
 - `default_project` (Required) - Default project to use when interacting with JIRA
 - `eausm` (Optional) - Set to `false` to disable EZ Agile Planning voting
 - `here_there_be_dragons` (Optional) - Set to `true` if you intend to use custom code to render JIRA custom field data
-- `default_fields` (Optional) - When displaying lists of issues, display these fields (and optional field widths) by default
+- `default_fields` (Optional) - When displaying lists of issues (e.g. `list`, `search`, `cat` for more than one issue), display these fields (and optional field widths) by default.  Key is always the left-most field, and is always included.
+- `issue_fields` (Optional) - When displaying issues (or a list) using `cat`, display only these fields by default.  Key is always the left-most field, and is always included.  Summary is not automatically included.  Note: The order of field specification precedence when using `cat` to determine field list is: command line, `issue_fields`, `default_fields`.
 - `no_format` (Optional) - Set to `true` if you would prefer Jirate not attempt to render JIRA comments and descriptions as markdown (JIRA text isn't markdown, so the markdown processor often gets this wrong)
 - `searches` (Optional) - List of JQL searches and their names.  The special search named `default` is applied when one runs `jirate search`.
 - `custom_reorder` (Optional) - Defaults to true. If set to false, custom field definitions will not reorder base JIRA fields when listing issues.
@@ -152,6 +153,9 @@ Each field in `custom_fields` is a dictionary. Jirate only cares about a few fie
   - `jirate attach PROJ-123 http://www.github.com Github Home`
 
 # Advanced
+## CSV output
+Jirate can output individual issues in CSV format, which is a bit easier to parse than JSON or text data.
+- `jirate -f csv [cat|search|sprint|components]`
 ## Templates
 Jirate has powerful templating - templates are a combination of Jinja2 and YAML.  Note that typical syntax differs from Jinja2 since double-braces are used by Jira, we use `{@` and `@}` instead.
 - Generate a template from an existing issue:

--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -90,8 +90,6 @@ class EscapedString(str):
 
 
 def color_string(string, color=None, bgcolor=None):
-    global fancy_output
-
     if fancy_output is not True:
         return string
 
@@ -115,7 +113,6 @@ def color_string(string, color=None, bgcolor=None):
 
 
 def link_string(text, url):
-    global fancy_output
     if not fancy_output:
         return None
 
@@ -125,8 +122,6 @@ def link_string(text, url):
 
 
 def issue_link_string(issue_key, baseurl=None):
-    global fancy_output
-
     if not baseurl or not fancy_output:
         return issue_key
 
@@ -278,9 +273,6 @@ vseparator = '┃'
 
 
 def vsep_print(linesplit=None, screen_width=0, *vals):
-    global _termsize
-    global vseparator
-
     sep = f' {vseparator} '
 
     fields = []

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -1389,7 +1389,7 @@ def sprint_info(args):
         board = info['boards'][board]
         board_by_id[board.id] = board
 
-    matrix = [['name', 'id', 'status', 'board']]
+    matrix = [['name', 'id', 'status', 'start', 'end', 'board']]
     for sprint in info['sprints']:
         sprint = info['sprints'][sprint]
         if sprint.state not in ('active', 'future') and not args.closed:
@@ -1398,7 +1398,7 @@ def sprint_info(args):
             board_name = board_by_id[sprint.originBoardId]
         except KeyError:
             board_name = '???'
-        matrix.append([sprint.name, sprint.id, sprint.state, board_name])
+        matrix.append([sprint.name, sprint.id, sprint.state, pretty_date(sprint.startDate), pretty_date(sprint.endDate), board_name])
     if len(info) > 1:
         render_matrix(matrix, fmt=args.format)
 

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -1238,6 +1238,11 @@ def cat(args):
             return (127, False)
         issues.append(issue)
 
+    if not args.fields:
+        fields = args.project.get_user_data('issue_fields')
+        if fields:
+            setattr(args, 'fields', fields)
+
     if args.format in ['csv']:
         print_issues(issues, args)
         return (0, False)

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -212,7 +212,8 @@ def print_issues_by_field(issue_list, args=None, exclude_fields=[]):
         for row in output:
             row.pop(column)
 
-    lines = render_matrix(output, fmt=args.format)
+    header = not (args.format in ['csv'])
+    lines = render_matrix(output, fmt=args.format, header=header)
     return lines
 
 
@@ -1156,17 +1157,29 @@ def print_eausm_votes(project, issue):
         print()
 
 
-def print_issue(project, issue_obj, verbose=False, no_comments=False, no_format=False):
+def print_issue(project, issue_obj, verbose=False, no_comments=False, no_format=False, allowed_fields=None):
     if verbose:
         # Get votes and watchers in verbose mode
         project.votes(issue_obj)
         project.watchers(issue_obj)
+
     issue = issue_obj.raw['fields']
+
+    if allowed_fields:
+        allowed_fields = parse_field_widths(allowed_fields)
+        disp = {}
+        allowed_ids = [project.field_to_id(field) for field in allowed_fields]
+        for field_id in allowed_ids:
+            if field_id in issue:
+                disp[field_id] = issue[field_id]
+        issue = disp
+
     key_link = issue_link_string(issue_obj.key, project.jira.server_url)
     lsize = max(len(key_link), max_field_width(issue, verbose, project.allow_code))
     lsize = max(lsize, len('Next States'))
 
-    vsep_print(' ', 0, key_link, lsize, issue['summary'])
+    if 'summary' in issue and issue['summary']:
+        vsep_print(' ', 0, key_link, lsize, issue['summary'])
     render_issue_fields(issue, verbose, project.allow_code, lsize)
 
     if verbose:
@@ -1179,7 +1192,7 @@ def print_issue(project, issue_obj, verbose=False, no_comments=False, no_format=
             vsep_print(None, 0, 'Next States', lsize, 'No valid transitions; cannot alter status')
 
     print()
-    if issue['description']:
+    if 'description' in issue and issue['description']:
         md_print(issue['description'], no_format)
         print()
 
@@ -1201,12 +1214,13 @@ def print_issue(project, issue_obj, verbose=False, no_comments=False, no_format=
     if 'subtasks' in issue and len(issue['subtasks']):
         print_subtasks(issue, project.jira.server_url)
 
-    for megalith in ('Epic', 'Feature'):
-        if issue['issuetype']['name'] == megalith:
-            ret = project.search_issues(f'"{megalith} Link" = "' + issue_obj.raw['key'] + '"')
-            _print_issue_list(f'Issues in {megalith}', ret, project.jira.server_url)
+    if 'issuetype' in issue:
+        for megalith in ('Epic', 'Feature'):
+            if issue['issuetype']['name'] == megalith:
+                ret = project.search_issues(f'"{megalith} Link" = "' + issue_obj.raw['key'] + '"')
+                _print_issue_list(f'Issues in {megalith}', ret, project.jira.server_url)
 
-    if no_comments:
+    if no_comments or 'comment' not in issue:
         return
     if issue['comment']['comments']:
         hbar_under('Comments')
@@ -1224,13 +1238,17 @@ def cat(args):
             return (127, False)
         issues.append(issue)
 
+    if args.format in ['csv']:
+        print_issues(issues, args)
+        return (0, False)
+
     if args.no_format:
         no_format = args.no_format
     else:
         no_format = args.project.get_user_data('no_format')
 
     for issue in issues:
-        print_issue(args.project, issue, args.verbose, args.no_comments, no_format)
+        print_issue(args.project, issue, args.verbose, args.no_comments, no_format, args.fields)
     return (0, False)
 
 
@@ -1372,7 +1390,7 @@ def sprint_info(args):
         # FIXME: This doesn't allow for field substring ("order" in the
         # "summary" field, for example)
         if not args.raw or 'order' not in args.raw.lower():
-            search = search + ' order by rank asc'
+            search = search + ' order by rank desc'
         issues = args.project.search_issues(search)
         print_issues(issues, args, exclude_fields=['sprint'])
         return (0, False)
@@ -1400,7 +1418,8 @@ def sprint_info(args):
             board_name = '???'
         matrix.append([sprint.name, sprint.id, sprint.state, pretty_date(sprint.startDate), pretty_date(sprint.endDate), board_name])
     if len(info) > 1:
-        render_matrix(matrix, fmt=args.format)
+        header = not (args.format in ['csv'])
+        render_matrix(matrix, fmt=args.format, header=header)
 
     return (0, False)
 
@@ -1557,6 +1576,7 @@ def create_parser():
     cmd.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
     cmd.add_argument('-N', '--no-comments', action='store_true', default=False, help='Skip comments')
     cmd.add_argument('-n', '--no-format', action='store_true', help='Do not format output using Markdown')
+    add_list_options(cmd)
     cmd.add_argument('issue_id', nargs='+', help='Target issue(s)', type=str.upper)
 
     cmd = parser.command('view', help='Display issue in browser', handler=view_issue)

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -978,7 +978,7 @@ def quote_reply(args):
     if not comment:
         return (1, False)
 
-    starting_text = f'Quoth [~{comment['author']['name']}] - {pretty_date(comment['updated'])}:\n'
+    starting_text = f"Quoth [~{comment['author']['name']}] - {pretty_date(comment['updated'])}:\n"
     starting_text = starting_text + '\n'.join(['┃ ' + item for item in comment['body'].strip().split('\n')])
     new_text = editor(starting_text)
     if 'visibility' in comment:

--- a/jirate/jira_fields.py
+++ b/jirate/jira_fields.py
@@ -410,7 +410,6 @@ def apply_schema_renderer(field):
 
 
 def func_from_path(filename, function, field, fields):
-    global _loaded_mods
     # Load a function from a file and run that
     import importlib.util
     import os
@@ -609,7 +608,6 @@ def field_ordering():
 
 
 def max_field_width(issue, verbose, allow_code):
-    global _fields
     width = 0
 
     for field_key in _fields:
@@ -621,8 +619,6 @@ def max_field_width(issue, verbose, allow_code):
 
 
 def render_issue_fields(issue, verbose=False, allow_code=False, width=None):
-    global _fields
-
     if not width:
         width = max_field_width(issue, verbose, allow_code)
 


### PR DESCRIPTION
- Allow CSV output of individual issues with a constrained set of fields
- Allow configuring default fields when using `cat`, specifically
- Show sprint start and end dates