### PR TITLE
Prep 0.8.18

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: jirate
-Version: 0.8.17
+Version: 0.8.18
 Summary: Python CLI for JIRA and Trello
 Author: Lon Hohberger
 Author-email: lon@metamorphism.com

--- a/jirate/__init__.py
+++ b/jirate/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/python3
 
-__version__ = '0.8.17'
+__version__ = '0.8.18'


### PR DESCRIPTION
Since build/push to PyPI happens after tags are pushed, I can prep this now for later, so I don't forget in case tons of commits come in between now and then.