### PR TITLE
jira: Sort fields table

### DIFF
--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -442,6 +442,7 @@ def issue_fields(args):
 
     if display:
         matrix = [['Field', 'Allowed Values']]
+        field_info = {}
         for field in fields:
             if field.startswith('customfield_'):
                 fname = nym(fields[field]['name'])
@@ -460,6 +461,9 @@ def issue_fields(args):
                     else:
                         values.append(val['id'])
                 fvalue = comma_separated(values)
+            field_info[fname] = fvalue
+        for fname in sorted([key for key in field_info]):
+            fvalue = field_info[fname]
             matrix.append([fname, fvalue])
         render_matrix(matrix)
         return (0, False)


### PR DESCRIPTION
When listing a lot of fields or debugging why a field is not available for an issue, it's helpful to sort the field name by what `jirate` accepts as input