### PR TITLE
jira: sort fields in generated templates

### DIFF
--- a/jirate/config.py
+++ b/jirate/config.py
@@ -21,9 +21,9 @@ def _str_presenter(dumper, data):
     return dumper.represent_scalar('tag:yaml.org,2002:str', data)
 
 
-def yaml_dump(info):
+def yaml_dump(info, **kwargs):
     yaml.representer.SafeRepresenter.add_representer(str, _str_presenter)
-    return yaml.safe_dump(info, allow_unicode=True)
+    return yaml.safe_dump(info, allow_unicode=True, **kwargs)
 
 
 # Allow YAML or JSON

--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -842,7 +842,7 @@ def generate_template(args):
     # TODO: allow customizing allow_fields in the config
     template = _generate_template(issue.raw['fields'], args.project.field_to_alias, args.project.issue, args.all_fields)
 
-    print(yaml_dump({'issues': [template]}))
+    print(yaml_dump({'issues': [template]}, sort_keys=False))
     return (0, True)
 
 
@@ -853,7 +853,7 @@ def _generate_template(raw_issue, translate_fields, fetch_issue=None, all_fields
         if allow_fields is not None:
             # Ensure these are in alias form, if set. Makes writing configs easier.
             allow_fields = [translate_fields(field) for field in allow_fields]
-        template = _trim_template(template, allow_fields)
+        template = _sort_template_fields(_trim_template(template, allow_fields))
     return template
 
 
@@ -923,6 +923,45 @@ def _trim_template(template, allow_fields=None):
         else:
             trimmed_fields[field] = value
     return trimmed_fields
+
+
+def _sort_template_fields(template, first_fields=None, last_fields=None):
+    """
+    Returns an identical template with fields sorted in a more human-accessible way
+    """
+    _subtasks = 'sub_tasks'
+    if first_fields is None:
+        # These fields, if present, will be first in the template, in this order
+        first_fields = [
+            'summary',
+            'issue_type',
+            'story_points',
+            ]
+    if last_fields is None:
+        # These fields, if present, will be last in the template, in this order
+        last_fields = [
+            'description',
+            _subtasks,
+            ]
+
+    # Use OrderedDict for the convenience of move_to_end()
+    template = OrderedDict(template)
+
+    for field in reversed(first_fields):
+        if field in template:
+            template.move_to_end(field, last=False)
+    for field in last_fields:
+        if field in template:
+            template.move_to_end(field, last=True)
+
+    # Each subtask's fields also need to be sorted
+    if _subtasks in template:
+        for i,subtask in enumerate(template[_subtasks]):
+            template[_subtasks][i] = _sort_template_fields(subtask, first_fields, last_fields)
+
+    # PyYAML refuses to take OrderedDicts, so turn this back into a regular dict
+    # (it will still preserve order)
+    return dict(template)
 
 
 def new_subtask(args):

--- a/jirate/tests/test_jira_cli.py
+++ b/jirate/tests/test_jira_cli.py
@@ -3,7 +3,7 @@
 from jirate.tests import fake_jira, fake_metadata, fake_fields
 from jirate.args import GenericArgs
 from jirate.jira_cli import _parse_creation_args, _create_from_template, _generate_template, \
-    validate_template
+    _sort_template_fields, validate_template
 from jirate.jboard import JiraProject
 from jirate.jira_fields import apply_field_renderers
 
@@ -254,6 +254,46 @@ def test_generate_template_subtasks():
     generated = {'issues': [generated]}
 
     assert actual == generated
+
+
+def test_sort_template_fields_parent():
+    actual = {'issue_type': 'Bug',
+              'summary': 'Test 4 (parent task)',
+              'sub_tasks': [
+                  {'issue_type': 'Sub-task',
+                   'summary': 'Test 5 (subtask of Test 4)'},
+                  {'issue_type': 'Sub-task',
+                   'description': 'Description of Test 6',
+                   'summary': 'Test 6 (subtask of Test 4)'}],
+              'description': 'Description of test 4 (parent task)'}
+    first_fields = ['summary']
+    last_fields = ['description', 'sub_tasks']
+
+    sorted_template = _sort_template_fields(actual, first_fields, last_fields)
+    parent_fields_actual = list(sorted_template.keys())
+    parent_fields_expected = ['summary', 'issue_type', 'description', 'sub_tasks']
+
+    assert parent_fields_actual == parent_fields_expected
+
+
+def test_sort_template_fields_subtask():
+    actual = {'issue_type': 'Bug',
+              'summary': 'Test 4 (parent task)',
+              'sub_tasks': [
+                  {'issue_type': 'Sub-task',
+                   'summary': 'Test 5 (subtask of Test 4)'},
+                  {'issue_type': 'Sub-task',
+                   'description': 'Description of Test 6',
+                   'summary': 'Test 6 (subtask of Test 4)'}],
+              'description': 'Description of test 4 (parent task)'}
+    first_fields = ['summary']
+    last_fields = ['description', 'sub_tasks']
+
+    sorted_template = _sort_template_fields(actual, first_fields, last_fields)
+    subtask_fields_actual = list(sorted_template['sub_tasks'][1].keys())
+    subtask_fields_expected = ['summary', 'issue_type', 'description']
+
+    assert subtask_fields_actual == subtask_fields_expected
 
 
 def test_validate_templates_good():


### PR DESCRIPTION
YAML dict key order doesn't actually matter, but humans may want to read generated template YAML and so it makes sense to sort template fields in a way that makes them easier to read.

This makes it so that happens by default. The _sort_template_fields function takes parameters to determine the exact order used, with sensible defaults. We don't expose those as configurable values or args but we can trivially do that if we find a need for it.