### PR TITLE
jira: Default to cloud-style input for users

### DIFF
--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -13,7 +13,7 @@ from jira.utils import json_loads as _json_loads
 from jira.resources import Issue, User
 
 from jirate.decor import nym
-from jirate.jira_input import transmogrify_input
+from jirate.jira_input import transmogrify_input, setup_input
 
 
 # lhh - seems python 3.12.4 doesn't let us simply replace
@@ -124,6 +124,7 @@ class Jirate(object):
         self._field_to_human = None
         jira.user = types.MethodType(_user_fix, jira)
         jira.user_by_key = types.MethodType(_user_by_key, jira)
+        setup_input(jira)  # Need to make input more object-private
 
     def _issue_key(self, alias):
         if isinstance(alias, str):

--- a/jirate/jira_input.py
+++ b/jirate/jira_input.py
@@ -22,6 +22,10 @@ def in_name(value):
     return {'name': value}
 
 
+def in_account_id(value):
+    return {'accountId': value}
+
+
 def in_value(value):
     return {'value': value}
 
@@ -48,7 +52,7 @@ _input_renderers = {
     'option-with-child': in_owc,
     'issuelink': in_key,
     'resolution': in_name,
-    'user': in_name
+    'user': in_account_id
 }
 
 
@@ -56,8 +60,11 @@ def _input_list(vals, attrib):
     return [{attrib: val} for val in vals]
 
 
+def in_account_id_list(vals):
+    return _input_list(vals, 'accountId')
+
+
 def in_user_list(vals):
-    # Could be key, which is why it's separate
     return _input_list(vals, 'name')
 
 
@@ -74,7 +81,7 @@ def in_string_list(vals):
 
 
 _input_array_renderers = {
-    'user': in_user_list,
+    'user': in_account_id_list,
     'option': in_value_list,
     'version': in_name_list,
     'group': in_name_list,
@@ -99,6 +106,26 @@ _custom_field_input = {
     'com.pyxis.greenhopper.jira:gh-sprint': in_sprint_field,
     'com.atlassian.jpo:jpo-custom-field-parent': in_issue_key,
     'com.pyxis.greenhopper.jira:gh-epic-link': in_issue_key
+}
+
+
+_dc_field_input_basic = {
+    'user': in_name
+}
+
+
+_dc_field_input_array = {
+    'user': in_user_list
+}
+
+
+_cloud_field_input_basic = {
+    'user': in_account_id
+}
+
+
+_cloud_field_input_array = {
+    'user': in_account_id_list
 }
 
 
@@ -237,3 +264,17 @@ def transmogrify_input(field_definitions, **args):
             continue
         output[field_id] = transmogrify_value(value, field_definitions[field_id])
     return (output, unused)
+
+
+def setup_input(jira):
+    if jira._is_cloud:
+        for field in _cloud_field_input_basic:
+            _input_renderers[field] = _cloud_field_input_basic[field]
+        for field in _cloud_field_input_array:
+            _input_array_renderers[field] = _cloud_field_input_array[field]
+        return
+
+    for field in _dc_field_input_basic:
+        _input_renderers[field] = _dc_field_input_basic[field]
+    for field in _dc_field_input_array:
+        _input_array_renderers[field] = _dc_field_input_array[field]

--- a/jirate/tests/test_input.py
+++ b/jirate/tests/test_input.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
+from jirate.args import GenericArgs
 from jirate.tests import fake_metadata, fake_fields
-from jirate.jira_input import transmogrify_input
+from jirate.jira_input import transmogrify_input, setup_input
 from jirate.jira_input import check_value, allowed_value_validate, in_owc
 
 import os
@@ -77,9 +78,23 @@ def test_trans_array_versions():
     assert transmogrify_input(fake_metadata, **inp) == (out, {})
 
 
-def test_trans_array_users():
+def test_trans_array_users_dc():
+    arg = GenericArgs()
+    arg._is_cloud = False
+    setup_input(arg)
+
     inp = {'array_of_users': 'user1,user2'}
     out = {'customfield_1234571': [{'name': 'user1'}, {'name': 'user2'}]}
+
+    assert transmogrify_input(fake_metadata, **inp) == (out, {})
+
+    arg._is_cloud = True
+    setup_input(arg)
+
+
+def test_trans_array_users_cloud():
+    inp = {'array_of_users': 'user1,user2'}
+    out = {'customfield_1234571': [{'accountId': 'user1'}, {'accountId': 'user2'}]}
 
     assert transmogrify_input(fake_metadata, **inp) == (out, {})
 
@@ -177,9 +192,24 @@ def test_trans_empty_out():
     assert transmogrify_input(fake_metadata, **inp) == (out, inp)
 
 
-def test_trans_user_value():
+def test_trans_user_value_dc():
+    arg = GenericArgs()
+    arg._is_cloud = False
+    setup_input(arg)
+
     inp = {'User Value': 'user1'}
     out = {'customfield_1234580': {'name': 'user1'}}
+
+    assert transmogrify_input(fake_metadata, **inp) == (out, {})
+
+    # Back to default
+    arg._is_cloud = True
+    setup_input(arg)
+
+
+def test_trans_user_value_cloud():
+    inp = {'User Value': 'user1'}
+    out = {'customfield_1234580': {'accountId': 'user1'}}
 
     assert transmogrify_input(fake_metadata, **inp) == (out, {})
 


### PR DESCRIPTION
The input for users and user lists in cloud changed from the `name` attribute to the `accountId` attribute.