### PR TITLE
Fix CSV output

### DIFF
--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -5,6 +5,7 @@
 
 import copy
 import csv
+import io
 import os
 import re
 import sys
@@ -609,14 +610,28 @@ def pretty_matrix(matrix, header=True, header_bar=True):
 def native_csv(matrix, header=True, header_bar=True):
     lines = 0
     # header_bar currently unused
-    csv_out = csv.writer(sys.stdout)
+    #
+    # I tried a couple different ways to try to get the CSV
+    # writer to not append a random newline character, but failed.
+    #   Methods tried:
+    #     sys.stdout.reconfigure (reset newline to '' or None)
+    #     Use a stringio and write that directly
+    # So, this is the most brute-force: Create a stringio to
+    # satisfy what csv.writer() wants, then zap it iteration and
+    # strip() it before printing. In this way, the newline being
+    # rendered by csv.writer() is banished.
+    output = io.StringIO()
+    csv_out = csv.writer(output)
     if header:
         start = 0
     else:
         start = 1
     for row in matrix[start:]:
+        output.seek(0)
+        output.truncate(0)
         unrender_row = [ansi_ctrl_strip(val) for val in row]
         csv_out.writerow(unrender_row)
+        print(output.getvalue().rstrip('\r\n'))
         lines = lines + 1
 
     return lines

--- a/jirate/decor.py
+++ b/jirate/decor.py
@@ -607,9 +607,7 @@ def pretty_matrix(matrix, header=True, header_bar=True):
     return lines
 
 
-def native_csv(matrix, header=True, header_bar=True):
-    lines = 0
-    # header_bar currently unused
+def _csv_string(items: list):
     #
     # I tried a couple different ways to try to get the CSV
     # writer to not append a random newline character, but failed.
@@ -620,18 +618,25 @@ def native_csv(matrix, header=True, header_bar=True):
     # satisfy what csv.writer() wants, then zap it iteration and
     # strip() it before printing. In this way, the newline being
     # rendered by csv.writer() is banished.
+    #
+    # This is heavy-handed, but we can at least build unit tests
+    # that work correctly
     output = io.StringIO()
     csv_out = csv.writer(output)
+    csv_out.writerow(items)
+    return output.getvalue().rstrip('\r\n')
+
+
+def native_csv(matrix, header=True, header_bar=True):
+    lines = 0
+    # header_bar currently unused
     if header:
         start = 0
     else:
         start = 1
     for row in matrix[start:]:
-        output.seek(0)
-        output.truncate(0)
         unrender_row = [ansi_ctrl_strip(val) for val in row]
-        csv_out.writerow(unrender_row)
-        print(output.getvalue().rstrip('\r\n'))
+        print(_csv_string(unrender_row))
         lines = lines + 1
 
     return lines

--- a/jirate/tests/test_decor.py
+++ b/jirate/tests/test_decor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from jirate.decor import truncate, parse_params, comma_separated, link_string, EscapedString, ansi_ctrl_strip, nym, color_string
+from jirate.decor import truncate, parse_params, comma_separated, link_string, EscapedString, ansi_ctrl_strip, nym, color_string, _csv_string
 
 import jirate.decor
 
@@ -222,3 +222,15 @@ def test_nym_custom_remove():
 def test_nym_empty_input():
     assert nym('') == ''
     assert nym(None) is None
+
+
+def test_csv_string():
+    assert _csv_string(['Hello',' world!']) == 'Hello, world!'
+
+
+def test_csv_string_quoted_carriage_returns():
+    assert _csv_string(['Hello',' world!\r']) == 'Hello," world!\r"'
+
+
+def test_csv_string_quoted_newlines():
+    assert _csv_string(['Hello',' world!\n']) == 'Hello," world!\n"'


### PR DESCRIPTION
These two commands were not producing equivalent results:
`jirate -f csv search -r 'key in (ABC-123)' --fields key | sha256sum`
`jirate search -qr 'key in (ABC-123)' | sha256sum`

This is because the CSV writer (at least on python 3.14.4) was always appending a carriage return (0xa) even when the output's newline was set to `''` or `None`.

This merge renders CSV output one line at a time, but produces repeatable results that can be tested without writing a new CSV output module.