### PR TITLE
jira: Render complicated/ignored fields as json data if requested

### DIFF
--- a/jirate/jira_cli.py
+++ b/jirate/jira_cli.py
@@ -543,6 +543,10 @@ def issue_fields(args):
         (_, orig_value) = render_field_data(field_id, issue.raw['fields'], True, args.project.allow_code)
         print(orig_value)
         return (0, False)
+    if args.operation == 'get-json':
+        (_, orig_value) = render_field_data(field_id, issue.raw['fields'], True, as_json=True)
+        print(orig_value)
+        return (0, False)
 
     # Update a field
     if field_id not in fields:
@@ -1838,7 +1842,7 @@ def create_parser():
 
     cmd = parser.command('field', help='Update field values for an issue', handler=issue_fields)
     cmd.add_argument('issue', help='Issue')
-    cmd.add_argument('operation', help='Operation', choices=['add', 'get', 'set', 'remove', 'sub'])
+    cmd.add_argument('operation', help='Operation', choices=['add', 'get', 'get-json', 'set', 'remove', 'sub'])
     cmd.add_argument('name', help='Name of field to update')
     cmd.add_argument('values', help='Value(s) to update', nargs='*')
 

--- a/jirate/jira_fields.py
+++ b/jirate/jira_fields.py
@@ -14,8 +14,6 @@ from jirate.jira_custom import custom_field_renderers
 def json(field, fields=None, as_object=False):
     if as_object:
         return field
-    if isinstance(field, str):
-        return field
     return _json.dumps(field)
 
 

--- a/jirate/jira_fields.py
+++ b/jirate/jira_fields.py
@@ -564,7 +564,7 @@ def jirate_field(field_key):
     return None
 
 
-def render_field_data(field_key, fields, verbose=False, allow_code=False, as_object=False):
+def render_field_data(field_key, fields, verbose=False, allow_code=False, as_object=False, as_json=False):
     """Render the field using custom-renderers or user-supplied code
     Note: you must first configure the rendering engine using apply_field_renderers()
 
@@ -578,11 +578,12 @@ def render_field_data(field_key, fields, verbose=False, allow_code=False, as_obj
 
     Returns:
       field_name: Human-readable field name (string)
-      value: Rendered field value (string)
+      value: Rendered field value (string, object, or json data as string)
     """
+    if field_key in fields and as_json:
+        return field_key, json(fields[field_key])
     if field_key not in _fields:
-        # Ignored fields should be parseable as JSON
-        return field_key, json(fields[field_key], as_object=as_object)
+        return field_key, fields[field_key]
     field_name = _fields[field_key]['name']
     if field_key not in fields and field_key not in _jirate_fields:
         return field_name, None

--- a/jirate/jira_fields.py
+++ b/jirate/jira_fields.py
@@ -578,8 +578,11 @@ def render_field_data(field_key, fields, verbose=False, allow_code=False, as_obj
       field_name: Human-readable field name (string)
       value: Rendered field value (string, object, or json data as string)
     """
-    if field_key in fields and as_json:
-        return field_key, json(fields[field_key])
+    if as_json:
+        if field_key in fields:
+            return field_key, json(fields[field_key])
+        else:
+            raise ValueError(f'{field_key} not in issue fields')
     if field_key not in _fields:
         return field_key, fields[field_key]
     field_name = _fields[field_key]['name']

--- a/jirate/jira_fields.py
+++ b/jirate/jira_fields.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import json as _json
 import re  # NOQA
 from collections import OrderedDict
 from jirate.decor import pretty_date, vsep_print, comma_separated
@@ -10,6 +11,14 @@ from jirate.jira_custom import custom_field_renderers
 # Field rendering functions. Return a string, or None if you want the field
 # suppressed.
 #
+def json(field, fields=None, as_object=False):
+    if as_object:
+        return field
+    if isinstance(field, str):
+        return field
+    return _json.dumps(field)
+
+
 def _list_of_key(field, keys, as_object=False):
     if not isinstance(keys, list) and not isinstance(keys, tuple):
         keys = [keys]
@@ -572,7 +581,8 @@ def render_field_data(field_key, fields, verbose=False, allow_code=False, as_obj
       value: Rendered field value (string)
     """
     if field_key not in _fields:
-        return field_key, fields[field_key]
+        # Ignored fields should be parseable as JSON
+        return field_key, json(fields[field_key], as_object=as_object)
     field_name = _fields[field_key]['name']
     if field_key not in fields and field_key not in _jirate_fields:
         return field_name, None


### PR DESCRIPTION
Much of the automatic field rendering is based on human-readable things, so we ignored a bunch of fields that have a lot of information in the basic outputs and render them manually elsewhere.

These fields were still available with `jirate field XXX get`, but the resulting output is a Python dictionary.

When writing Python wrappers, people will use the Python objects; e.g.

   `issue.field('issuelinks')` => returns an array of dict

When writing shell wrappers around the text output from jirate, people seem to be likely to use use jq / awk / cut / etc.; e.g.

   `jirate field xxx get issuelinks` => returns a JSON blob (or should)

A quick follow-up would be to make `get` for any field return json data, perhaps with a flag.