### PR TITLE
fix(jboard): preserve explicit project when parent is cross-project

### DIFF
--- a/jirate/jboard.py
+++ b/jirate/jboard.py
@@ -557,9 +557,13 @@ class Jirate(object):
         # a subtask. Also resolve parent issue.
         if 'parent' in args and isinstance(args['parent'], str):
             parent_issue = self.issue(args['parent'])
-            project = parent_issue.raw['fields']['project']['key']
             args['parent'] = parent_issue.key
-            args['project'] = project
+            # Only inherit the parent's project if no explicit project was specified.
+            # Jira supports cross-project parent links, so unconditionally overriding
+            # the project here breaks creation of issues whose parent is in a different
+            # project (e.g. an OSPRH Epic parented to a RHOSSTRAT Initiative).
+            if 'project' not in args:
+                args['project'] = parent_issue.raw['fields']['project']['key']
 
         # Transmogrify other fields
         (new_args, extra) = transmogrify_input(field_definitions, **args)


### PR DESCRIPTION
When a parent issue is in a different project than the one being created, the previous code unconditionally overwrote args['project'] with the parent's project key. This caused the JIRA client to look up issue types in the parent's project rather than the target project, raising a KeyError when the target issue type (e.g. Epic) existed in the target project but not in the parent's project.

Jira supports cross-project parent links. Only fall back to the parent's project when no explicit project has been specified (i.e. subtask creation).

Assisted-by: Claude Code